### PR TITLE
Add TrackVisit missing params test

### DIFF
--- a/tests/Feature/App/Http/Controllers/Middleware/TrackVisitTest.php
+++ b/tests/Feature/App/Http/Controllers/Middleware/TrackVisitTest.php
@@ -2,6 +2,7 @@
 
 use function Pest\Laravel\get;
 use function Pest\Laravel\post;
+use function Pest\Laravel\withServerVariables;
 
 use Facades\App\Actions\TrackVisit;
 use Illuminate\Support\Facades\Route;
@@ -46,5 +47,10 @@ it('does not track requests that want JSON', function () {
     get('/', ['Accept' => 'application/json']);
 });
 
-it('only tracks if all required parameters are available')
-    ->todo();
+it('only tracks if all required parameters are available', function () {
+    TrackVisit::shouldReceive('track')->never();
+
+    withServerVariables(['REMOTE_ADDR' => null]);
+
+    get('/');
+});


### PR DESCRIPTION
## Summary
- complete TODO in TrackVisit middleware test to ensure TrackVisit isn't called when request parameters are missing

## Testing
- `./vendor/bin/pest` *(fails: connection errors to api.pirsch.io)*

------
https://chatgpt.com/codex/tasks/task_e_683f8d975fb88321922e8b38550a8e47