### PR TITLE
Add Horizon link in nav

### DIFF
--- a/resources/views/components/nav.blade.php
+++ b/resources/views/components/nav.blade.php
@@ -86,6 +86,13 @@
                     </x-dropdown.item>
                 @endif
 
+                @can('viewHorizon')
+                    <x-dropdown.item href="{{ route('horizon.index') }}">
+                        <x-heroicon-o-bolt class="size-4" />
+                        Horizon
+                    </x-dropdown.item>
+                @endcan
+
                 <x-dropdown.divider />
 
                 <x-dropdown.item href="https://github.com/settings" target="_blank">


### PR DESCRIPTION
## Summary
- allow authorized users to access Horizon directly from the nav

## Testing
- `./vendor/bin/pest` *(fails: could not find driver)*

------
https://chatgpt.com/codex/tasks/task_e_68402337d83c8321954846092bbaaa65