### PR TITLE
Add Atom feed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
         "livewire/livewire": "^3.5",
         "spatie/image": "*",
         "spatie/laravel-activitylog": "^4.10",
+        "spatie/laravel-feed": "^4.4",
         "spatie/laravel-livewire-wizard": "^2.4",
         "spatie/laravel-sitemap": "^7.3",
         "tempest/highlight": "^2.11"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6648db3ac5fdc8b4e5fa68d4c6feaaea",
+    "content-hash": "2d3b8f9beed502d95ba6dfae291edabb",
     "packages": [
         {
             "name": "andreiio/blade-iconoir",
@@ -3240,16 +3240,16 @@
         },
         {
             "name": "league/flysystem",
-            "version": "3.29.1",
+            "version": "3.30.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem.git",
-                "reference": "edc1bb7c86fab0776c3287dbd19b5fa278347319"
+                "reference": "2203e3151755d874bb2943649dae1eb8533ac93e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/edc1bb7c86fab0776c3287dbd19b5fa278347319",
-                "reference": "edc1bb7c86fab0776c3287dbd19b5fa278347319",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/2203e3151755d874bb2943649dae1eb8533ac93e",
+                "reference": "2203e3151755d874bb2943649dae1eb8533ac93e",
                 "shasum": ""
             },
             "require": {
@@ -3273,13 +3273,13 @@
                 "composer/semver": "^3.0",
                 "ext-fileinfo": "*",
                 "ext-ftp": "*",
-                "ext-mongodb": "^1.3",
+                "ext-mongodb": "^1.3|^2",
                 "ext-zip": "*",
                 "friendsofphp/php-cs-fixer": "^3.5",
                 "google/cloud-storage": "^1.23",
                 "guzzlehttp/psr7": "^2.6",
                 "microsoft/azure-storage-blob": "^1.1",
-                "mongodb/mongodb": "^1.2",
+                "mongodb/mongodb": "^1.2|^2",
                 "phpseclib/phpseclib": "^3.0.36",
                 "phpstan/phpstan": "^1.10",
                 "phpunit/phpunit": "^9.5.11|^10.0",
@@ -3317,22 +3317,22 @@
             ],
             "support": {
                 "issues": "https://github.com/thephpleague/flysystem/issues",
-                "source": "https://github.com/thephpleague/flysystem/tree/3.29.1"
+                "source": "https://github.com/thephpleague/flysystem/tree/3.30.0"
             },
-            "time": "2024-10-08T08:58:34+00:00"
+            "time": "2025-06-25T13:29:59+00:00"
         },
         {
             "name": "league/flysystem-local",
-            "version": "3.29.0",
+            "version": "3.30.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem-local.git",
-                "reference": "e0e8d52ce4b2ed154148453d321e97c8e931bd27"
+                "reference": "6691915f77c7fb69adfb87dcd550052dc184ee10"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem-local/zipball/e0e8d52ce4b2ed154148453d321e97c8e931bd27",
-                "reference": "e0e8d52ce4b2ed154148453d321e97c8e931bd27",
+                "url": "https://api.github.com/repos/thephpleague/flysystem-local/zipball/6691915f77c7fb69adfb87dcd550052dc184ee10",
+                "reference": "6691915f77c7fb69adfb87dcd550052dc184ee10",
                 "shasum": ""
             },
             "require": {
@@ -3366,9 +3366,9 @@
                 "local"
             ],
             "support": {
-                "source": "https://github.com/thephpleague/flysystem-local/tree/3.29.0"
+                "source": "https://github.com/thephpleague/flysystem-local/tree/3.30.0"
             },
-            "time": "2024-08-09T21:24:39+00:00"
+            "time": "2025-05-21T10:34:19+00:00"
         },
         {
             "name": "league/mime-type-detection",
@@ -4110,16 +4110,16 @@
         },
         {
             "name": "nesbot/carbon",
-            "version": "3.10.0",
+            "version": "3.10.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/CarbonPHP/carbon.git",
-                "reference": "c1397390dd0a7e0f11660f0ae20f753d88c1f3d9"
+                "reference": "1fd1935b2d90aef2f093c5e35f7ae1257c448d00"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/CarbonPHP/carbon/zipball/c1397390dd0a7e0f11660f0ae20f753d88c1f3d9",
-                "reference": "c1397390dd0a7e0f11660f0ae20f753d88c1f3d9",
+                "url": "https://api.github.com/repos/CarbonPHP/carbon/zipball/1fd1935b2d90aef2f093c5e35f7ae1257c448d00",
+                "reference": "1fd1935b2d90aef2f093c5e35f7ae1257c448d00",
                 "shasum": ""
             },
             "require": {
@@ -4211,7 +4211,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-06-12T10:24:28+00:00"
+            "time": "2025-06-21T15:19:35+00:00"
         },
         {
             "name": "nette/php-generator",
@@ -5863,21 +5863,20 @@
         },
         {
             "name": "ramsey/uuid",
-            "version": "4.8.1",
+            "version": "4.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ramsey/uuid.git",
-                "reference": "fdf4dd4e2ff1813111bd0ad58d7a1ddbb5b56c28"
+                "reference": "4e0e23cc785f0724a0e838279a9eb03f28b092a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ramsey/uuid/zipball/fdf4dd4e2ff1813111bd0ad58d7a1ddbb5b56c28",
-                "reference": "fdf4dd4e2ff1813111bd0ad58d7a1ddbb5b56c28",
+                "url": "https://api.github.com/repos/ramsey/uuid/zipball/4e0e23cc785f0724a0e838279a9eb03f28b092a0",
+                "reference": "4e0e23cc785f0724a0e838279a9eb03f28b092a0",
                 "shasum": ""
             },
             "require": {
                 "brick/math": "^0.8.8 || ^0.9 || ^0.10 || ^0.11 || ^0.12 || ^0.13",
-                "ext-json": "*",
                 "php": "^8.0",
                 "ramsey/collection": "^1.2 || ^2.0"
             },
@@ -5936,9 +5935,9 @@
             ],
             "support": {
                 "issues": "https://github.com/ramsey/uuid/issues",
-                "source": "https://github.com/ramsey/uuid/tree/4.8.1"
+                "source": "https://github.com/ramsey/uuid/tree/4.9.0"
             },
-            "time": "2025-06-01T06:28:46+00:00"
+            "time": "2025-06-25T14:20:11+00:00"
         },
         {
             "name": "ryangjchandler/blade-capture-directive",
@@ -6588,6 +6587,98 @@
                 }
             ],
             "time": "2025-02-17T09:53:23+00:00"
+        },
+        {
+            "name": "spatie/laravel-feed",
+            "version": "4.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/laravel-feed.git",
+                "reference": "4b41c89837cb170e04db57f07f6315b33411e31d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/laravel-feed/zipball/4b41c89837cb170e04db57f07f6315b33411e31d",
+                "reference": "4b41c89837cb170e04db57f07f6315b33411e31d",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/contracts": "^10.0|^11.0|^12.0",
+                "illuminate/http": "^10.0|^11.0|^12.0",
+                "illuminate/support": "^10.0|^11.0|^12.0",
+                "php": "^8.2",
+                "spatie/laravel-package-tools": "^1.15"
+            },
+            "require-dev": {
+                "orchestra/testbench": "^8.0|^9.0|^10.0",
+                "pestphp/pest": "^2.0|^3.0",
+                "spatie/pest-plugin-snapshots": "^2.0",
+                "spatie/test-time": "^1.2"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Spatie\\Feed\\FeedServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\Feed\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jolita Grazyte",
+                    "email": "jolita@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian De Deyne",
+                    "email": "sebastian@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Patrick Organ",
+                    "homepage": "https://github.com/patinthehat",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Generate rss feeds",
+            "homepage": "https://github.com/spatie/laravel-feed",
+            "keywords": [
+                "laravel",
+                "laravel-feed",
+                "rss",
+                "spatie"
+            ],
+            "support": {
+                "source": "https://github.com/spatie/laravel-feed/tree/4.4.2"
+            },
+            "funding": [
+                {
+                    "url": "https://spatie.be/open-source/support-us",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/spatie",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-04-17T09:49:53+00:00"
         },
         {
             "name": "spatie/laravel-livewire-wizard",
@@ -13401,12 +13492,12 @@
     ],
     "aliases": [],
     "minimum-stability": "beta",
-    "stability-flags": {},
+    "stability-flags": [],
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "php": "^8.4"
     },
-    "platform-dev": {},
+    "platform-dev": [],
     "plugin-api-version": "2.6.0"
 }

--- a/config/feed.php
+++ b/config/feed.php
@@ -1,0 +1,55 @@
+<?php
+
+return [
+    'feeds' => [
+        'main' => [
+            /*
+             * Here you can specify which class and method will return
+             * the items that should appear in the feed. For example:
+             * [App\Model::class, 'getAllFeedItems']
+             *
+             * You can also pass an argument to that method. Note that their key must be the name of the parameter:
+             * [App\Model::class, 'getAllFeedItems', 'parameterName' => 'argument']
+             */
+            'items' => [App\Models\Post::class, 'getFeedItems'],
+
+            /*
+             * The feed will be available on this url.
+             */
+            'url' => '/feed',
+
+            'title' => config('app.name') . ' posts',
+            'description' => 'Latest articles from ' . config('app.name'),
+            'language' => 'en-US',
+
+            /*
+             * The image to display for the feed. For Atom feeds, this is displayed as
+             * a banner/logo; for RSS and JSON feeds, it's displayed as an icon.
+             * An empty value omits the image attribute from the feed.
+             */
+            'image' => '',
+
+            /*
+             * The format of the feed. Acceptable values are 'rss', 'atom', or 'json'.
+             */
+            'format' => 'atom',
+
+            /*
+             * The view that will render the feed.
+             */
+            'view' => 'feed::atom',
+
+            /*
+             * The mime type to be used in the <link> tag. Set to an empty string to automatically
+             * determine the correct value.
+             */
+            'type' => '',
+
+            /*
+             * The content type for the feed response. Set to an empty string to automatically
+             * determine the correct value.
+             */
+            'contentType' => '',
+        ],
+    ],
+];

--- a/public/vendor/feed/atom.xsl
+++ b/public/vendor/feed/atom.xsl
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:atom="http://www.w3.org/2005/Atom">
+    <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+    <xsl:template match="/">
+        <html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+            <head>
+                <title>
+                    RSS Feed | <xsl:value-of select="/atom:feed/atom:title"/>
+                </title>
+                <meta charset="utf-8"/>
+                <meta http-equiv="content-type" content="text/html; charset=utf-8"/>
+                <meta name="viewport" content="width=device-width, initial-scale=1"/>
+                <link rel="stylesheet" href="/vendor/feed/style.css"/>
+            </head>
+            <body>
+                <main class="layout-content">
+                    <h1 class="flex items-start">
+                        <!-- https://commons.wikimedia.org/wiki/File:Feed-icon.svg -->
+                        <svg xmlns="http://www.w3.org/2000/svg" version="1.1"
+                             class="mr-5"
+                             style="flex-shrink: 0; width: 1em; height: 1em;"
+                             viewBox="0 0 256 256">
+                            <defs>
+                                <linearGradient x1="0.085" y1="0.085" x2="0.915" y2="0.915"
+                                                id="RSSg">
+                                    <stop offset="0.0" stop-color="#E3702D"/>
+                                    <stop offset="0.1071" stop-color="#EA7D31"/>
+                                    <stop offset="0.3503" stop-color="#F69537"/>
+                                    <stop offset="0.5" stop-color="#FB9E3A"/>
+                                    <stop offset="0.7016" stop-color="#EA7C31"/>
+                                    <stop offset="0.8866" stop-color="#DE642B"/>
+                                    <stop offset="1.0" stop-color="#D95B29"/>
+                                </linearGradient>
+                            </defs>
+                            <rect width="256" height="256" rx="55" ry="55" x="0" y="0"
+                                  fill="#CC5D15"/>
+                            <rect width="246" height="246" rx="50" ry="50" x="5" y="5"
+                                  fill="#F49C52"/>
+                            <rect width="236" height="236" rx="47" ry="47" x="10" y="10"
+                                  fill="url(#RSSg)"/>
+                            <circle cx="68" cy="189" r="24" fill="#FFF"/>
+                            <path
+                                d="M160 213h-34a82 82 0 0 0 -82 -82v-34a116 116 0 0 1 116 116z"
+                                fill="#FFF"/>
+                            <path
+                                d="M184 213A140 140 0 0 0 44 73 V 38a175 175 0 0 1 175 175z"
+                                fill="#FFF"/>
+                        </svg>
+                        RSS Feed
+                    </h1>
+                    <h2><xsl:value-of select="/atom:feed/atom:title"/></h2>
+                    <p>
+                        <xsl:value-of select="/atom:feed/atom:subtitle"/>
+                    </p>
+                    <hr/>
+                    <xsl:for-each select="/atom:feed/atom:entry">
+                        <div class="post">
+                            <div class="title">
+                                <a>
+                                    <xsl:attribute name="href">
+                                        <xsl:value-of select="atom:link/@href"/>
+                                    </xsl:attribute>
+                                    <xsl:value-of select="atom:title"/>
+                                </a>
+                            </div>
+
+                            <div class="summary">
+                                <xsl:value-of select="atom:summary" disable-output-escaping="yes"/>
+                            </div>
+
+                            <div class="published-info">
+                                Published on
+                                <xsl:value-of select="substring(atom:updated, 0, 11)" /> by <xsl:value-of select="atom:author/atom:name"/>
+                            </div>
+                        </div>
+                    </xsl:for-each>
+                </main>
+            </body>
+        </html>
+    </xsl:template>
+</xsl:stylesheet>

--- a/public/vendor/feed/style.css
+++ b/public/vendor/feed/style.css
@@ -1,0 +1,37 @@
+.layout-content {
+    max-width: 640px;
+    margin-left: auto;
+    margin-right: auto;
+
+    font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+}
+
+hr {
+    margin: 2rem 0;
+}
+
+.post {
+    margin-bottom: 2rem;
+}
+
+.post .title {
+    font-size: 1.5rem;
+    line-height: 2rem;
+    margin-bottom: 1rem;
+}
+
+.post .summary {
+    font-size: 1rem;
+    line-height: 1.5rem;
+    margin-bottom: 1rem;
+}
+
+.post .published-info {
+    font-size: 0.75rem;
+    line-height: 1rem;
+    color: #666;
+}
+
+img {
+    max-width: 100%;
+}

--- a/resources/views/components/app.blade.php
+++ b/resources/views/components/app.blade.php
@@ -37,6 +37,7 @@
         <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Outfit:wght@100..900&display=swap" />
 
         <link rel="canonical" href="{{ $canonical }}" />
+        <x-feed-links />
     </head>
     <body {{ $attributes->class('font-light text-gray-600') }}>
         <div class="flex flex-col min-h-screen">

--- a/resources/views/components/nav.blade.php
+++ b/resources/views/components/nav.blade.php
@@ -200,7 +200,7 @@
             </x-dropdown.divider>
 
             <x-dropdown.item
-                href="#"
+                href="{{ route('feeds.main') }}"
                 data-pirsch-event='Clicked "Atom feed"'
             >
                 <x-heroicon-o-rss class="size-4" />

--- a/routes/web.php
+++ b/routes/web.php
@@ -31,6 +31,8 @@ Route::get('/links/create', LinkWizard::class)
 Route::get('/recommends/{slug}', ShowMerchantController::class)
     ->name('merchants.show');
 
+Route::feeds();
+
 // This route needs to be the last one so all others take precedence.
 Route::get('/{post:slug}', ShowPostController::class)
     ->name('posts.show');

--- a/tests/Feature/App/Http/Controllers/FeedControllerTest.php
+++ b/tests/Feature/App/Http/Controllers/FeedControllerTest.php
@@ -1,0 +1,17 @@
+<?php
+
+use App\Models\Post;
+
+use function Pest\Laravel\get;
+
+it('generates the atom feed', function () {
+    $post = Post::factory()->create([
+        'content' => 'UniqueContentFromTest',
+        'description' => 'Short description',
+    ]);
+
+    get(route('feeds.main'))
+        ->assertOk()
+        ->assertSee('Short description')
+        ->assertDontSee('UniqueContentFromTest');
+});


### PR DESCRIPTION
## Summary
- install spatie/laravel-feed package
- configure feed
- implement Feedable in `Post`
- expose feed route and navigation link
- surface feed links in page head
- add tests for the feed

## Testing
- `./vendor/bin/pint -v`
- `php artisan test` *(fails: HTTP request returned status code 401)*

------
https://chatgpt.com/codex/tasks/task_e_685f0871f2288321bfeb78076bcf6188