### PR TITLE
feat: add horizon link in filament

### DIFF
--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -76,12 +76,20 @@ class AdminPanelProvider extends PanelProvider
                     ->url('/')
                     ->icon('heroicon-o-arrow-right-circle')
                     ->sort(0),
+                NavigationItem::make('Horizon')
+                    ->url('/horizon')
+                    ->icon('icon-horizon')
+                    ->sort(1),
             ])
             ->userMenuItems([
                 MenuItem::make()
                     ->label('Go to site')
                     ->url('/')
                     ->icon('heroicon-o-arrow-right-circle'),
+                MenuItem::make()
+                    ->label('Horizon')
+                    ->url('/horizon')
+                    ->icon('icon-horizon'),
             ]);
     }
 }


### PR DESCRIPTION
## Summary
- add Horizon navigation item in Filament panel
- add Horizon user menu entry for quick access
- use custom Horizon icon for these links

## Testing
- `php -d memory_limit=512M artisan test` *(fails: Allowed memory size of 134217728 bytes exhausted)*

------
https://chatgpt.com/codex/tasks/task_e_68b4576a5ce88321911e0e0452c6e02c