### PR TITLE
Add copy actions for revision view fields

### DIFF
--- a/app/Filament/Resources/Revisions/Pages/ViewRevision.php
+++ b/app/Filament/Resources/Revisions/Pages/ViewRevision.php
@@ -2,13 +2,13 @@
 
 namespace App\Filament\Resources\Revisions\Pages;
 
+use App\Filament\Resources\Revisions\RevisionResource;
 use App\Models\Revision;
-use Illuminate\Support\Js;
 use Filament\Actions\Action;
 use Filament\Actions\DeleteAction;
 use Filament\Notifications\Notification;
 use Filament\Resources\Pages\ViewRecord;
-use App\Filament\Resources\Revisions\RevisionResource;
+use Illuminate\Support\Js;
 
 class ViewRevision extends ViewRecord
 {
@@ -17,18 +17,14 @@ class ViewRevision extends ViewRecord
     protected function getHeaderActions() : array
     {
         return [
-            Action::make('copy')
-                ->label('Copy as Markdown')
-                ->tooltip('Copy as Markdown')
-                ->hiddenLabel(true)
-                ->color('gray')
-                ->icon('heroicon-o-clipboard-document')
-                ->alpineClickHandler(fn (Revision $record) => 'window.navigator.clipboard.writeText(' . Js::from($record->data['content']) . ')'),
+            $this->makeCopyMarkdownAction(),
+            $this->makeCopyAction('title'),
+            $this->makeCopyAction('description'),
+            $this->makeCopyAction('content'),
 
             Action::make('complete')
                 ->label('Mark as completed')
                 ->tooltip('Mark as completed')
-                ->hiddenLabel(true)
                 ->icon('heroicon-o-check')
                 ->action(function (Revision $record) {
                     $record->update(['completed_at' => now()]);
@@ -43,5 +39,47 @@ class ViewRevision extends ViewRecord
 
             DeleteAction::make(),
         ];
+    }
+
+    protected function makeCopyAction(string $field) : Action
+    {
+        $label = str_replace('_', ' ', $field);
+        $labelTitleCase = ucwords($label);
+        $labelLowerCase = strtolower($label);
+
+        return Action::make("copy_{$field}")
+            ->label("Copy {$labelTitleCase}")
+            ->tooltip("Copy the {$labelLowerCase} to your clipboard")
+            ->color('gray')
+            ->icon('heroicon-o-clipboard-document')
+            ->alpineClickHandler(fn (Revision $record) => $this->copyToClipboardScript($record->data[$field] ?? null, "{$labelTitleCase} copied to your clipboard"))
+            ->disabled(fn (Revision $record) : bool => blank($record->data[$field] ?? null));
+    }
+
+    protected function makeCopyMarkdownAction() : Action
+    {
+        $message = 'Revision content copied to your clipboard';
+
+        return Action::make('copy')
+            ->label('Copy as Markdown')
+            ->tooltip('Copy the content as Markdown to your clipboard')
+            ->color('gray')
+            ->icon('heroicon-o-clipboard-document')
+            ->alpineClickHandler(fn (Revision $record) => $this->copyToClipboardScript($record->data['content'] ?? null, $message))
+            ->disabled(fn (Revision $record) : bool => blank($record->data['content'] ?? null));
+    }
+
+    protected function copyToClipboardScript(?string $value, string $message) : string
+    {
+        $valueJs = Js::from($value ?? '');
+        $messageJs = Js::from($message);
+
+        return <<<JS
+            window.navigator.clipboard.writeText({$valueJs});
+            \$tooltip({$messageJs}, {
+                theme: \$store.theme,
+                timeout: 2000,
+            });
+        JS;
     }
 }


### PR DESCRIPTION
## Summary
- add dedicated header actions to copy the revision title, description, and content to the clipboard with tooltip feedback
- centralize the copy-to-clipboard script helper for reuse across the new actions
- restore the original "Copy as Markdown" action using the shared helper so the full content action remains available

## Testing
- php -l app/Filament/Resources/Revisions/Pages/ViewRevision.php

------
https://chatgpt.com/codex/tasks/task_e_68c86cd0d0688321bfc9daf8c8d17a3c