### PR TITLE
Group revision copy actions

### DIFF
--- a/app/Filament/Resources/Revisions/Pages/ViewRevision.php
+++ b/app/Filament/Resources/Revisions/Pages/ViewRevision.php
@@ -9,6 +9,7 @@ use Filament\Actions\ActionGroup;
 use Filament\Actions\DeleteAction;
 use Filament\Notifications\Notification;
 use Filament\Resources\Pages\ViewRecord;
+use Filament\Support\Enums\IconPosition;
 use App\Filament\Resources\Revisions\RevisionResource;
 
 class ViewRevision extends ViewRecord
@@ -24,14 +25,12 @@ class ViewRevision extends ViewRecord
                 $this->makeCopyAction('content'),
             ])
                 ->label('Copy')
-                ->icon('heroicon-o-clipboard-document')
+                ->icon('heroicon-o-chevron-down')
+                ->iconPosition(IconPosition::After)
                 ->button()
-                ->color('gray')
-                ->tooltip('Copy revision values to your clipboard'),
+                ->color('gray'),
 
             Action::make('complete')
-                ->label('Mark as completed')
-                ->tooltip('Mark as completed')
                 ->icon('heroicon-o-check')
                 ->action(function (Revision $record) {
                     $record->update(['completed_at' => now()]);
@@ -56,9 +55,6 @@ class ViewRevision extends ViewRecord
 
         return Action::make("copy_{$field}")
             ->label("Copy {$labelTitleCase}")
-            ->tooltip("Copy the {$labelLowerCase} to your clipboard")
-            ->color('gray')
-            ->icon('heroicon-o-clipboard-document')
             ->alpineClickHandler(fn (Revision $record) => $this->copyToClipboardScript($record->data[$field] ?? null, "{$labelTitleCase} copied to your clipboard"))
             ->disabled(fn (Revision $record) : bool => blank($record->data[$field] ?? null));
     }

--- a/app/Filament/Resources/Revisions/Pages/ViewRevision.php
+++ b/app/Filament/Resources/Revisions/Pages/ViewRevision.php
@@ -2,13 +2,14 @@
 
 namespace App\Filament\Resources\Revisions\Pages;
 
-use App\Filament\Resources\Revisions\RevisionResource;
 use App\Models\Revision;
+use Illuminate\Support\Js;
 use Filament\Actions\Action;
+use Filament\Actions\ActionGroup;
 use Filament\Actions\DeleteAction;
 use Filament\Notifications\Notification;
 use Filament\Resources\Pages\ViewRecord;
-use Illuminate\Support\Js;
+use App\Filament\Resources\Revisions\RevisionResource;
 
 class ViewRevision extends ViewRecord
 {
@@ -17,10 +18,16 @@ class ViewRevision extends ViewRecord
     protected function getHeaderActions() : array
     {
         return [
-            $this->makeCopyMarkdownAction(),
-            $this->makeCopyAction('title'),
-            $this->makeCopyAction('description'),
-            $this->makeCopyAction('content'),
+            ActionGroup::make([
+                $this->makeCopyAction('title'),
+                $this->makeCopyAction('description'),
+                $this->makeCopyAction('content'),
+            ])
+                ->label('Copy')
+                ->icon('heroicon-o-clipboard-document')
+                ->button()
+                ->color('gray')
+                ->tooltip('Copy revision values to your clipboard'),
 
             Action::make('complete')
                 ->label('Mark as completed')
@@ -54,19 +61,6 @@ class ViewRevision extends ViewRecord
             ->icon('heroicon-o-clipboard-document')
             ->alpineClickHandler(fn (Revision $record) => $this->copyToClipboardScript($record->data[$field] ?? null, "{$labelTitleCase} copied to your clipboard"))
             ->disabled(fn (Revision $record) : bool => blank($record->data[$field] ?? null));
-    }
-
-    protected function makeCopyMarkdownAction() : Action
-    {
-        $message = 'Revision content copied to your clipboard';
-
-        return Action::make('copy')
-            ->label('Copy as Markdown')
-            ->tooltip('Copy the content as Markdown to your clipboard')
-            ->color('gray')
-            ->icon('heroicon-o-clipboard-document')
-            ->alpineClickHandler(fn (Revision $record) => $this->copyToClipboardScript($record->data['content'] ?? null, $message))
-            ->disabled(fn (Revision $record) : bool => blank($record->data['content'] ?? null));
     }
 
     protected function copyToClipboardScript(?string $value, string $message) : string


### PR DESCRIPTION
## Summary
- replace the standalone revision copy actions with an Action Group dropdown for title, description, and content
- remove the previous "Copy as Markdown" action per the new requirements

## Testing
- php -l app/Filament/Resources/Revisions/Pages/ViewRevision.php

------
https://chatgpt.com/codex/tasks/task_e_68c86cd0d0688321bfc9daf8c8d17a3c