### PR TITLE
Add tests for remaining notifications

### DIFF
--- a/tests/Feature/App/Notifications/CategoryPageRefreshedTest.php
+++ b/tests/Feature/App/Notifications/CategoryPageRefreshedTest.php
@@ -1,0 +1,39 @@
+<?php
+
+use App\Models\User;
+use App\Models\Category;
+use Illuminate\Support\HtmlString;
+use App\Notifications\CategoryPageRefreshed;
+
+it('renders as an email', function () {
+    $category = Category::factory()->create();
+
+    $result = new CategoryPageRefreshed($category);
+
+    $rendered = $result
+        ->toMail(User::factory()->create())
+        ->render();
+
+    expect($rendered)->toBeInstanceOf(HtmlString::class);
+});
+
+it('has the expected subject, content, and action', function () {
+    $category = Category::factory()->create(['name' => 'Laravel']);
+
+    $message = (new CategoryPageRefreshed($category))->toMail(User::factory()->create());
+
+    expect($message->subject)->toBe('A category page was just refreshed');
+    expect($message->introLines)->toHaveCount(1);
+    expect($message->introLines[0])->toContain('Laravel');
+    expect($message->actionText)->toBe('Check Category Page');
+    expect($message->actionUrl)->toBe(route('categories.show', $category));
+});
+
+it('sends via the mail channel and is queueable', function () {
+    $category = Category::factory()->create();
+
+    $notification = new CategoryPageRefreshed($category);
+
+    expect($notification->via(User::factory()->create()))->toBe(['mail']);
+    expect($notification)->toBeInstanceOf(\Illuminate\Contracts\Queue\ShouldQueue::class);
+});

--- a/tests/Feature/App/Notifications/JobFetchedTest.php
+++ b/tests/Feature/App/Notifications/JobFetchedTest.php
@@ -1,0 +1,37 @@
+<?php
+
+use App\Models\Job;
+use App\Models\User;
+use App\Notifications\JobFetched;
+use Illuminate\Support\HtmlString;
+
+it('renders as an email', function () {
+    $job = Job::factory()->create();
+
+    $rendered = (new JobFetched($job))
+        ->toMail(User::factory()->create())
+        ->render();
+
+    expect($rendered)->toBeInstanceOf(HtmlString::class);
+});
+
+it('has the expected subject, content, and action', function () {
+    $job = Job::factory()->create(['title' => 'Senior Laravel Developer']);
+
+    $message = (new JobFetched($job))->toMail(User::factory()->create());
+
+    expect($message->subject)->toBe('A new job was just fetched');
+    expect($message->introLines)->toHaveCount(1);
+    expect($message->introLines[0])->toContain('Senior Laravel Developer');
+    expect($message->actionText)->toBe('Check Job');
+    expect($message->actionUrl)->toBe(route('jobs.show', $job));
+});
+
+it('sends via the mail channel and is queueable', function () {
+    $job = Job::factory()->create();
+
+    $notification = new JobFetched($job);
+
+    expect($notification->via(User::factory()->create()))->toBe(['mail']);
+    expect($notification)->toBeInstanceOf(\Illuminate\Contracts\Queue\ShouldQueue::class);
+});

--- a/tests/Feature/App/Notifications/LinkDeclinedTest.php
+++ b/tests/Feature/App/Notifications/LinkDeclinedTest.php
@@ -1,0 +1,37 @@
+<?php
+
+use App\Models\Link;
+use App\Models\User;
+use Illuminate\Support\HtmlString;
+use App\Notifications\LinkDeclined;
+
+it('renders as an email', function () {
+    $link = Link::factory()->create();
+
+    $rendered = (new LinkDeclined($link, 'We already covered this topic.'))
+        ->toMail(User::factory()->create())
+        ->render();
+
+    expect($rendered)->toBeInstanceOf(HtmlString::class);
+});
+
+it('has the expected subject, greeting, and content', function () {
+    $link = Link::factory()->create();
+    $reason = 'We already covered this topic.';
+
+    $message = (new LinkDeclined($link, $reason))->toMail(User::factory()->create());
+
+    expect($message->subject)->toBe('Your link was declined');
+    expect($message->greeting)->toBe('Thank you for submitting, but your link was declined.');
+    expect($message->introLines)->toHaveCount(1);
+    expect($message->introLines[0])->toBe($reason);
+});
+
+it('sends via the mail channel and is queueable', function () {
+    $link = Link::factory()->create();
+
+    $notification = new LinkDeclined($link, 'Duplicate content.');
+
+    expect($notification->via(User::factory()->create()))->toBe(['mail']);
+    expect($notification)->toBeInstanceOf(\Illuminate\Contracts\Queue\ShouldQueue::class);
+});

--- a/tests/Feature/App/Notifications/NewReportTest.php
+++ b/tests/Feature/App/Notifications/NewReportTest.php
@@ -1,0 +1,37 @@
+<?php
+
+use App\Models\User;
+use App\Models\Report;
+use App\Notifications\NewReport;
+use Illuminate\Support\HtmlString;
+
+it('renders as an email', function () {
+    $report = Report::factory()->create();
+
+    $rendered = (new NewReport($report))
+        ->toMail(User::factory()->create())
+        ->render();
+
+    expect($rendered)->toBeInstanceOf(HtmlString::class);
+});
+
+it('has the expected subject, content, and action', function () {
+    $report = Report::factory()->create();
+
+    $message = (new NewReport($report))->toMail(User::factory()->create());
+
+    expect($message->subject)->toBe('A new report is available');
+    expect($message->introLines)->toHaveCount(1);
+    expect($message->introLines[0])->toContain($report->post->title);
+    expect($message->actionText)->toBe('Check Report');
+    expect($message->actionUrl)->not()->toBeEmpty();
+});
+
+it('sends via the mail channel and is queueable', function () {
+    $report = Report::factory()->create();
+
+    $notification = new NewReport($report);
+
+    expect($notification->via(User::factory()->create()))->toBe(['mail']);
+    expect($notification)->toBeInstanceOf(\Illuminate\Contracts\Queue\ShouldQueue::class);
+});

--- a/tests/Feature/App/Notifications/NewRevisionTest.php
+++ b/tests/Feature/App/Notifications/NewRevisionTest.php
@@ -1,0 +1,37 @@
+<?php
+
+use App\Models\User;
+use App\Models\Revision;
+use App\Notifications\NewRevision;
+use Illuminate\Support\HtmlString;
+
+it('renders as an email', function () {
+    $revision = Revision::factory()->create();
+
+    $rendered = (new NewRevision($revision))
+        ->toMail(User::factory()->create())
+        ->render();
+
+    expect($rendered)->toBeInstanceOf(HtmlString::class);
+});
+
+it('has the expected subject, content, and action', function () {
+    $revision = Revision::factory()->create();
+
+    $message = (new NewRevision($revision))->toMail(User::factory()->create());
+
+    expect($message->subject)->toBe('A new revision is available');
+    expect($message->introLines)->toHaveCount(1);
+    expect($message->introLines[0])->toContain($revision->report->post->title);
+    expect($message->actionText)->toBe('Check Revision');
+    expect($message->actionUrl)->not()->toBeEmpty();
+});
+
+it('sends via the mail channel and is queueable', function () {
+    $revision = Revision::factory()->create();
+
+    $notification = new NewRevision($revision);
+
+    expect($notification->via(User::factory()->create()))->toBe(['mail']);
+    expect($notification)->toBeInstanceOf(\Illuminate\Contracts\Queue\ShouldQueue::class);
+});

--- a/tests/Feature/App/Notifications/NewUserCreatedTest.php
+++ b/tests/Feature/App/Notifications/NewUserCreatedTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Support\HtmlString;
+use App\Notifications\NewUserCreated;
+
+it('renders as an email', function () {
+    $user = User::factory()->create();
+
+    $rendered = (new NewUserCreated($user))
+        ->toMail(User::factory()->create())
+        ->render();
+
+    expect($rendered)->toBeInstanceOf(HtmlString::class);
+});
+
+it('has the expected subject, content, and action', function () {
+    $user = User::factory()->create(['name' => 'Taylor Otwell']);
+
+    $message = (new NewUserCreated($user))->toMail(User::factory()->create());
+
+    expect($message->subject)->toBe('A new user was just created');
+    expect($message->introLines)->toHaveCount(1);
+    expect($message->introLines[0])->toContain('Taylor Otwell');
+    expect($message->actionText)->toBe('Check Profile');
+    expect($message->actionUrl)->toBe(route('authors.show', $user));
+});
+
+it('sends via the mail channel and is queueable', function () {
+    $user = User::factory()->create();
+
+    $notification = new NewUserCreated($user);
+
+    expect($notification->via(User::factory()->create()))->toBe(['mail']);
+    expect($notification)->toBeInstanceOf(\Illuminate\Contracts\Queue\ShouldQueue::class);
+});


### PR DESCRIPTION
## Summary
- add comprehensive Pest coverage for category refresh, job fetched, link declined, new revision, new report, and new user notifications
- verify email rendering, copy, action URLs, and queue configuration for each notification

## Testing
- ./vendor/bin/pest tests/Feature/App/Notifications/CategoryPageRefreshedTest.php
- ./vendor/bin/pest tests/Feature/App/Notifications/JobFetchedTest.php
- ./vendor/bin/pest tests/Feature/App/Notifications/LinkDeclinedTest.php
- ./vendor/bin/pest tests/Feature/App/Notifications/NewRevisionTest.php
- ./vendor/bin/pest tests/Feature/App/Notifications/NewReportTest.php
- ./vendor/bin/pest tests/Feature/App/Notifications/NewUserCreatedTest.php

------
https://chatgpt.com/codex/tasks/task_e_68e25a3138588321a1012699382c84c1