### PR TITLE
Improve remote handling in job posting schema

### DIFF
--- a/app/Console/Commands/IngestJobFeedsCommand.php
+++ b/app/Console/Commands/IngestJobFeedsCommand.php
@@ -3,10 +3,10 @@
 namespace App\Console\Commands;
 
 use App\Models\Job;
+use App\Feed\FeedItem;
 use App\Jobs\ScrapeJob;
 use Illuminate\Console\Command;
 use App\Actions\DiscoverFeedItems;
-use App\Feed\FeedItem;
 use Illuminate\Support\Collection;
 use Symfony\Component\Console\Attribute\AsCommand;
 
@@ -70,7 +70,7 @@ class IngestJobFeedsCommand extends Command
                     );
                 }
 
-                $this->info("Queued " . $toQueue->count() . " new item(s) from '$name'.");
+                $this->info('Queued ' . $toQueue->count() . " new item(s) from '$name'.");
             });
     }
 

--- a/app/Filament/Resources/LinkResource.php
+++ b/app/Filament/Resources/LinkResource.php
@@ -224,7 +224,7 @@ class LinkResource extends Resource
                     Action::make('decline')
                         ->schema([
                             Textarea::make('reason')
-                            ->nullable(),
+                                ->nullable(),
                         ])
                         ->action(function (Link $record, array $data) {
                             $record->decline($data['reason']);

--- a/app/Http/Controllers/Jobs/ShowJobController.php
+++ b/app/Http/Controllers/Jobs/ShowJobController.php
@@ -5,11 +5,15 @@ namespace App\Http\Controllers\Jobs;
 use App\Models\Job;
 use Illuminate\View\View;
 use App\Http\Controllers\Controller;
+use App\Support\Schema\JobPostingSchema;
 
 class ShowJobController extends Controller
 {
     public function __invoke(Job $job) : View
     {
-        return view('jobs.show', compact('job'));
+        return view('jobs.show', [
+            'job' => $job,
+            'jobPostingSchema' => JobPostingSchema::fromJob($job),
+        ]);
     }
 }

--- a/app/Support/Schema/JobPostingSchema.php
+++ b/app/Support/Schema/JobPostingSchema.php
@@ -1,0 +1,289 @@
+<?php
+
+namespace App\Support\Schema;
+
+use App\Models\Job;
+
+use function collect;
+
+use Illuminate\Support\Str;
+
+class JobPostingSchema
+{
+    public static function fromJob(Job $job) : array
+    {
+        $locations = collect($job->locations ?? [])
+            ->filter()
+            ->values()
+            ->all();
+
+        $isRemote = self::isRemote($job, $locations);
+
+        $jobLocations = self::buildJobLocations($locations, $isRemote);
+        $applicantLocationRequirements = self::buildApplicantLocationRequirements($locations, $isRemote);
+
+        $validThrough = optional($job->created_at)
+            ?->copy()
+            ->addDays(30)
+            ->toIso8601String();
+
+        $schema = [
+            '@context' => 'https://schema.org/',
+            '@type' => 'JobPosting',
+            'title' => $job->title,
+            'description' => $job->description,
+            'identifier' => [
+                '@type' => 'PropertyValue',
+                'name' => $job->company->name,
+                'value' => (string) $job->id,
+            ],
+            'datePosted' => optional($job->created_at)?->toIso8601String(),
+            'validThrough' => $validThrough,
+            'employmentType' => 'FULL_TIME',
+            'hiringOrganization' => [
+                '@type' => 'Organization',
+                'name' => $job->company->name,
+                'sameAs' => $job->company->url,
+                'logo' => $job->company->logo,
+            ],
+            'jobLocationType' => $isRemote ? 'TELECOMMUTE' : null,
+            'jobLocation' => $jobLocations,
+            'applicantLocationRequirements' => $applicantLocationRequirements,
+            'baseSalary' => [
+                '@type' => 'MonetaryAmount',
+                'currency' => $job->currency ?? 'USD',
+                'value' => [
+                    '@type' => 'QuantitativeValue',
+                    'minValue' => $job->min_salary,
+                    'maxValue' => $job->max_salary,
+                    'unitText' => 'YEAR',
+                ],
+            ],
+            'directApply' => false,
+        ];
+
+        return array_filter(
+            $schema,
+            fn ($value) => null !== $value && ([] !== $value || is_bool($value))
+        );
+    }
+
+    /**
+     * @param  array<int, string>  $locations
+     * @return array<int, array<string, mixed>>|array<string, mixed>
+     */
+    private static function buildJobLocations(array $locations, bool $isRemote) : array
+    {
+        if ([] === $locations) {
+            if ($isRemote) {
+                return self::remotePlace();
+            }
+
+            return [];
+        }
+
+        $places = collect($locations)
+            ->filter()
+            ->map(fn (string $location) => self::buildPlaceFromLocation($location, $isRemote))
+            ->filter()
+            ->values();
+
+        if ($places->isEmpty() && $isRemote) {
+            return self::remotePlace();
+        }
+
+        return 1 === $places->count()
+            ? $places->first()
+            : $places->all();
+    }
+
+    /**
+     * @param  array<int, string>  $locations
+     * @return array<int, array<string, string>>|array<string, string>
+     */
+    private static function buildApplicantLocationRequirements(array $locations, bool $isRemote) : array
+    {
+        $countries = collect($locations)
+            ->map(fn (string $location) => self::extractCountry($location))
+            ->filter()
+            ->unique()
+            ->values();
+
+        if ($countries->isEmpty()) {
+            if ($isRemote) {
+                return self::worldwideApplicantRequirement();
+            }
+
+            return [];
+        }
+
+        if (1 === $countries->count()) {
+            return self::countryApplicantRequirement($countries->first());
+        }
+
+        return $countries
+            ->map(fn (string $country) => self::countryApplicantRequirement($country))
+            ->all();
+    }
+
+    private static function buildPlaceFromLocation(string $location, bool $isRemote) : ?array
+    {
+        [$country, $locality, $region] = self::extractLocationParts($location);
+
+        if (null === $country && null === $locality && null === $region) {
+            if ($isRemote || self::containsRemoteKeyword($location)) {
+                return self::remotePlace($location);
+            }
+
+            return null;
+        }
+
+        $address = [
+            '@type' => 'PostalAddress',
+        ];
+
+        if (null !== $locality) {
+            $address['addressLocality'] = $locality;
+        }
+
+        if (null !== $region) {
+            $address['addressRegion'] = $region;
+        }
+
+        $address['addressCountry'] = $country ?? 'Worldwide';
+
+        return [
+            '@type' => 'Place',
+            'name' => '' !== trim($location) ? trim($location) : ($locality ?? $country ?? 'Remote'),
+            'address' => $address,
+        ];
+    }
+
+    /**
+     * @return array{0: string|null, 1: string|null, 2: string|null}
+     */
+    private static function extractLocationParts(string $location) : array
+    {
+        $segments = array_values(
+            array_filter(
+                array_map(
+                    fn (string $segment) => self::sanitizeSegment($segment),
+                    explode(',', $location)
+                ),
+                fn (string $segment) => '' !== $segment
+            )
+        );
+
+        if ([] === $segments) {
+            return [null, null, null];
+        }
+
+        $country = array_pop($segments);
+        $locality = [] !== $segments ? array_shift($segments) : null;
+        $region = [] !== $segments ? implode(', ', $segments) : null;
+
+        return [$country, $locality, $region];
+    }
+
+    private static function extractCountry(string $location) : ?string
+    {
+        [$country] = self::extractLocationParts($location);
+
+        return $country;
+    }
+
+    private static function sanitizeSegment(string $segment) : string
+    {
+        $sanitized = trim($segment);
+
+        $sanitized = preg_replace_callback(
+            '/\(([^)]*)\)/',
+            fn (array $matches) => self::containsRemoteKeyword($matches[1]) ? '' : $matches[0],
+            $sanitized
+        );
+
+        foreach (self::remoteKeywords() as $keyword) {
+            $sanitized = preg_replace('/\b' . preg_quote($keyword, '/') . '\b/i', '', $sanitized);
+        }
+
+        $sanitized = preg_replace('/[-–—]/', ' ', $sanitized);
+
+        $sanitized = preg_replace('/\s{2,}/', ' ', (string) $sanitized);
+
+        return trim((string) $sanitized, " \t\n\r\0\x0B,.-");
+    }
+
+    private static function remotePlace(?string $label = null) : array
+    {
+        return [
+            '@type' => 'Place',
+            'name' => self::resolveRemoteLabel($label),
+            'address' => [
+                '@type' => 'PostalAddress',
+                'addressCountry' => 'Worldwide',
+            ],
+        ];
+    }
+
+    private static function resolveRemoteLabel(?string $label) : string
+    {
+        $resolved = trim((string) $label);
+
+        return '' !== $resolved ? $resolved : 'Remote';
+    }
+
+    private static function isRemote(Job $job, array $locations) : bool
+    {
+        $setting = trim((string) $job->setting);
+
+        if ('' !== $setting) {
+            return self::containsRemoteKeyword($setting);
+        }
+
+        return collect($locations)->contains(fn (string $location) => self::containsRemoteKeyword($location));
+    }
+
+    private static function containsRemoteKeyword(string $value) : bool
+    {
+        $haystack = Str::of($value)->lower();
+
+        foreach (self::remoteKeywords() as $keyword) {
+            if ($haystack->contains($keyword)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private static function remoteKeywords() : array
+    {
+        return [
+            'remote',
+            'telecommute',
+            'distributed',
+            'anywhere',
+            'worldwide',
+            'global',
+        ];
+    }
+
+    private static function worldwideApplicantRequirement() : array
+    {
+        return [
+            '@type' => 'Country',
+            'name' => 'Worldwide',
+        ];
+    }
+
+    private static function countryApplicantRequirement(string $country) : array
+    {
+        return [
+            '@type' => 'Country',
+            'name' => $country,
+        ];
+    }
+}

--- a/resources/views/jobs/show.blade.php
+++ b/resources/views/jobs/show.blade.php
@@ -96,40 +96,6 @@
     </article>
 
     <script type="application/ld+json">
-        {
-            "@@context": "https://schema.org/",
-            "@@type": "JobPosting",
-            "title": @json($job->title),
-            "description": @json($job->description),
-            "identifier": {
-                "@@type": "PropertyValue",
-                "name": @json($job->company->name),
-                "value": @json((string) $job->id)
-            },
-            "datePosted": @json(optional($job->created_at)->toIso8601String()),
-            "employmentType": "FULL_TIME",
-            "hiringOrganization": {
-                "@@type": "Organization",
-                "name": @json($job->company->name),
-                "sameAs": @json($job->company->url),
-                "logo": @json($job->company->logo)
-            },
-            "jobLocationType": @json($job->setting === 'fully-remote' ? 'TELECOMMUTE' : null),
-            "jobLocation": {
-                "@@type": "Place",
-                "name": @json(collect($job->locations)->first())
-            },
-            "baseSalary": {
-                "@@type": "MonetaryAmount",
-                "currency": @json($job->currency ?? 'USD'),
-                "value": {
-                    "@@type": "QuantitativeValue",
-                    "minValue": @json($job->min_salary),
-                    "maxValue": @json($job->max_salary),
-                    "unitText": "YEAR"
-                }
-            },
-            "directApply": false
-        }
+        {!! json_encode($jobPostingSchema, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) !!}
     </script>
 </x-app>

--- a/tests/Feature/App/Http/Controllers/Jobs/ShowJobControllerTest.php
+++ b/tests/Feature/App/Http/Controllers/Jobs/ShowJobControllerTest.php
@@ -4,6 +4,9 @@ use App\Models\Job;
 
 use function Pest\Laravel\get;
 
+use Illuminate\Support\Carbon;
+use Symfony\Component\DomCrawler\Crawler;
+
 it('shows a job', function () {
     $job = Job::factory()->create();
 
@@ -19,13 +22,106 @@ it('returns 404 for unknown job', function () {
 });
 
 it('renders JobPosting JSON-LD on the job detail page', function () {
-    $job = Job::factory()->create();
+    Carbon::setTestNow(Carbon::create(2024, 1, 1, 0, 0, 0));
 
+    $job = Job::factory()->create([
+        'locations' => ['Paris, France'],
+        'created_at' => Carbon::now(),
+        'updated_at' => Carbon::now(),
+    ]);
+
+    $schema = extractJobPostingSchema($job);
+
+    expect($schema['@type'])->toBe('JobPosting');
+    expect($schema['title'])->toBe($job->title);
+    expect($schema['validThrough'])->toBe(Carbon::now()->addDays(30)->toIso8601String());
+    expect($schema['applicantLocationRequirements'])
+        ->toBe([
+            '@type' => 'Country',
+            'name' => 'France',
+        ]);
+
+    expect($schema['jobLocation'])
+        ->toMatchArray([
+            '@type' => 'Place',
+            'name' => 'Paris, France',
+            'address' => [
+                '@type' => 'PostalAddress',
+                'addressLocality' => 'Paris',
+                'addressCountry' => 'France',
+            ],
+        ]);
+
+    Carbon::setTestNow();
+});
+
+it('adds remote defaults when the job setting uses an alternate remote label', function () {
+    $job = Job::factory()->create([
+        'locations' => [],
+        'setting' => 'Remote',
+    ]);
+
+    $schema = extractJobPostingSchema($job);
+
+    expect($schema['jobLocationType'])->toBe('TELECOMMUTE');
+    expect($schema['jobLocation'])
+        ->toMatchArray([
+            '@type' => 'Place',
+            'name' => 'Remote',
+            'address' => [
+                '@type' => 'PostalAddress',
+                'addressCountry' => 'Worldwide',
+            ],
+        ]);
+
+    expect($schema['applicantLocationRequirements'])
+        ->toMatchArray([
+            '@type' => 'Country',
+            'name' => 'Worldwide',
+        ]);
+});
+
+it('removes remote keywords from location strings while keeping address data', function () {
+    $job = Job::factory()->create([
+        'locations' => ['Berlin, Germany (Remote)'],
+        'setting' => 'fully-remote',
+    ]);
+
+    $schema = extractJobPostingSchema($job);
+
+    expect($schema['jobLocation'])
+        ->toMatchArray([
+            '@type' => 'Place',
+            'name' => 'Berlin, Germany (Remote)',
+            'address' => [
+                '@type' => 'PostalAddress',
+                'addressLocality' => 'Berlin',
+                'addressCountry' => 'Germany',
+            ],
+        ]);
+
+    expect($schema['applicantLocationRequirements'])
+        ->toMatchArray([
+            '@type' => 'Country',
+            'name' => 'Germany',
+        ]);
+});
+
+/**
+ * @return array<string, mixed>
+ */
+function extractJobPostingSchema(Job $job) : array
+{
     $response = get(route('jobs.show', $job->slug));
 
     $response->assertOk();
 
     $response->assertSee('<script type="application/ld+json">', false);
-    $response->assertSee('"@type": "JobPosting"', false);
-    $response->assertSee('"title": ' . json_encode($job->title), false);
-});
+
+    $jsonLd = (new Crawler($response->getContent()))
+        ->filter('script[type="application/ld+json"]')
+        ->first()
+        ->text();
+
+    return json_decode(trim($jsonLd), true, 512, JSON_THROW_ON_ERROR);
+}


### PR DESCRIPTION
## Summary
- normalize the job posting schema builder to detect remote roles from flexible labels, sanitize location strings, and guarantee compliant jobLocation/applicantLocationRequirements payloads
- cover the remote scenarios with job detail feature tests that exercise alternate remote labels and remote-tagged location strings

## Testing
- php vendor/bin/pint --parallel
- php artisan test --filter=ShowJobControllerTest

------
https://chatgpt.com/codex/tasks/task_e_68e27f276c508321b0c098be8698d0b3