### PR TITLE
Clarify AGENTS and blog skill docs

### DIFF
--- a/.agents/skills/file-first-posts/SKILL.md
+++ b/.agents/skills/file-first-posts/SKILL.md
@@ -10,7 +10,7 @@ metadata:
 ## Scope
 
 Use this skill when posts are managed from `resources/markdown/posts`.
-Pair with `post-writing` when creating or revising article copy so internal links and, for non-commercial posts, the related-posts Markdown list stay current.
+Pair with `post-writing` when revising copy, and with `seo-content` when search framing matters.
 
 ## Required Rules
 
@@ -29,13 +29,10 @@ Pair with `post-writing` when creating or revising article copy so internal link
 - Only first-party, non-commercial, non-sponsored `news` posts should be treated as news-sitemap candidates.
 - Fail loudly on invalid front matter, unknown authors/categories, or duplicate IDs/slugs.
 - Do not use Filament to create, edit, delete, or restore posts.
-- If an edit changes article copy or scope, refresh the post's internal links and, for non-commercial posts, the related-posts Markdown list before syncing.
-- Commercial posts (`is_commercial: true`) must not add or keep a related-posts or read-next block. Keep those pages focused on the conversion path already in the article.
-- On non-commercial posts, that related-posts block must use a smooth article-specific lead-in sentence, not a stock phrase, canned curiosity hook, or title echo.
-- Choose related posts because they are smart next reads for the current article, not because they happen to share a category.
-- Rewrite the related-post anchor text contextually instead of pasting destination post titles into the list.
-- Make those anchors sound like the reader's next useful click from this page, not like a shelf label copied from somewhere else.
-- Keep them plain and clear enough that the reader immediately gets why the next post is worth opening.
+- If an edit changes article copy or scope, refresh internal links and, for non-commercial posts, the related-posts list before syncing.
+- Commercial posts (`is_commercial: true`) must not include a related-posts or read-next block.
+- Non-commercial related-posts blocks must use a custom article-specific lead-in sentence ending with a colon, followed by clear, contextual anchors rather than pasted destination titles.
+- Pick related posts because they are the best next reads for this article, not because they share a category.
 - Do not open the public page or Filament just for a routine post edit. Use browser checks only when the post includes tricky rendering, embeds, custom HTML, unusual formatting, interactive behavior, a publishing-state change that needs confirmation, the article needs purposeful screenshots that materially help the reader, or the user explicitly asks for a visual check.
 
 ## Workflow
@@ -43,7 +40,7 @@ Pair with `post-writing` when creating or revising article copy so internal link
 1. Bootstrap files when needed:
    - run `php artisan app:export-posts`
 2. Edit the target file in `resources/markdown/posts`.
-   - if article copy changed, make sure internal links were updated and, for non-commercial posts, the related-posts Markdown list was added or refreshed with a natural lead-in that does not quote or rephrase the title
+   - if article copy changed, update internal links and, for non-commercial posts, add or refresh the related-posts list with a natural lead-in that does not quote or rephrase the title
 3. Capture and upload images before syncing:
    - if the article would be clearer or more trustworthy with original screenshots, capture them yourself when feasible instead of leaving a note for later
    - every image referenced by the post should end up on Cloudflare Images, not just the hero image

--- a/.agents/skills/framework-news-analysis/SKILL.md
+++ b/.agents/skills/framework-news-analysis/SKILL.md
@@ -11,7 +11,7 @@ metadata:
 
 Use when the task is to find, frame, and write the strongest weekly news or analysis post about a framework, library, tool, platform, or developer product.
 
-Pair with `post-writing`, `file-first-posts`, and `seo-content` for the actual post workflow and publishing rules.
+Pair with `post-writing`, `file-first-posts`, and `seo-content` for drafting, publishing, and search framing.
 
 ## Required Rules
 

--- a/.agents/skills/post-writing/SKILL.md
+++ b/.agents/skills/post-writing/SKILL.md
@@ -10,7 +10,7 @@ metadata:
 ## Scope
 
 Use for drafting or revising publication-ready posts in `resources/markdown/posts`.
-Pair with `seo-content` for Search intent, Discover/News judgment, titles, snippets, and internal linking.
+Pair with `seo-content` for search intent, Discover/News judgment, titles, snippets, and internal linking.
 
 ## Frontmatter Contract
 
@@ -28,7 +28,7 @@ Pair with `seo-content` for Search intent, Discover/News judgment, titles, snipp
 
 - Write for competent beginners first: plain language, short sentences, clear payoff.
 - Explain unavoidable technical terms in simple words the first time they appear.
-- Upload every image used in the post to Cloudflare Images with `php artisan blog:upload-image`, including featured images, inline screenshots, badges, logos, and comparison cards.
+- Upload every image used in the post to Cloudflare Images with `php artisan app:upload-post-image`, including featured images, inline screenshots, badges, logos, and comparison cards.
 - Do not leave local file paths or third-party hotlinked images in post Markdown.
 - For walkthroughs, dashboards, UI-heavy how-tos, comparisons, and reviews, actively look for places where an original screenshot, crop, or simple visual would make the article clearer or more credible.
 - Create those visuals yourself when feasible instead of leaving a TODO or only describing the interface in prose.
@@ -60,16 +60,14 @@ Pair with `seo-content` for Search intent, Discover/News judgment, titles, snipp
 - Avoid filler judgments in post copy such as "feels real", "feels natural", "feels polished", or similar vibe-based phrasing unless you are quoting or attributing a sourced opinion.
 - Every created or revised non-commercial post must include a short list of interesting posts to read next. If the post already has one, refresh it instead of duplicating it.
 - Commercial posts (`is_commercial: true`) must not include a related-posts, read-next, or follow-up reading block. Keep the ending focused on the conversion path already present in the article.
-- On non-commercial posts, the sentence before that list must be custom to the article. Do not reuse stock lead-ins, canned curiosity hooks, or repeatable templates across posts. Tie it to the page's specific topic, promise, friction point, or next step.
-- Do not quote, paraphrase, or simply restate the article title in that lead-in. It should read as a clear article-specific transition into the next useful links.
-- Format the non-commercial block as a custom lead-in sentence ending with a colon, then a standard Markdown list with one linked item per bullet, like this:
+- On non-commercial posts, use a custom article-specific lead-in sentence ending with a colon, then a standard Markdown list with one linked item per bullet, like this:
   Custom lead-in text for this specific article:
 
   - [Highly specific anchor text](/target-slug)
   - [Another highly specific anchor text](/another-target)
-- Do not copy and paste the destination post title as the anchor text by default. Rewrite the anchor so it fits the current article's context, stays accurate to the destination, and sparks enough curiosity to earn the click.
-- Write each anchor as the reader's most likely next question, tension, or payoff from this specific article. It should explain why that next post matters now, not just name the destination.
-- Favor clarity over cleverness. If the anchor sounds vague, ambiguous, or too cute, rewrite it in plainer language while keeping the curiosity.
+- Do not quote or lightly rephrase the article title in that lead-in.
+- Do not copy the destination post title as anchor text by default. Rewrite each anchor so it fits the current article's context, stays accurate, and makes the next click obvious.
+- Favor clarity over cleverness. If an anchor sounds vague, ambiguous, or too cute, rewrite it in plainer language.
 - Add as many recommendations as the topic honestly supports on non-commercial posts: usually at least 3, sometimes more, with a hard cap of 10. Do not pad the list with weak matches.
 - Pick recommended posts that genuinely extend the topic for this exact reader journey. Use editorial judgment, not category matching or obvious heuristics. You do not need to fully read every recommended post before linking it, but you should believe the recommendation makes sense.
 - When creating or revising a post, add or improve natural internal links in the body wherever a reader would want the next step, not only in the closing list.
@@ -109,6 +107,6 @@ Pair with `seo-content` for Search intent, Discover/News judgment, titles, snipp
    - title and description make a strong, accurate click promise
    - headings read naturally in the generated table of contents
    - contextual internal links were added or improved where helpful
-   - non-commercial posts have one up-to-date related-posts list with a custom, natural lead-in that does not echo the title and anchor text that is contextual rather than a pasted destination title
+   - non-commercial posts have one up-to-date related-posts list with a custom lead-in that does not echo the title and anchor text that is contextual rather than a pasted destination title
    - commercial posts do not include a related-posts, read-next, or follow-up reading block
    - code and links support the nearby claim

--- a/.agents/skills/seo-content/SKILL.md
+++ b/.agents/skills/seo-content/SKILL.md
@@ -53,12 +53,10 @@ Read these references as needed:
 - For posts intended to target Discover or Google News strongly, the main image should be original when feasible, not a logo, and at least 1200 px wide.
 - Keep the post's related-posts list current as part of that internal-linking pass on non-commercial posts. Update stale recommendations or anchors when the article's angle changes instead of leaving an outdated list behind.
 - Commercial posts (`is_commercial: true`) must not include a related-posts, read-next, or follow-up reading block. Keep those pages focused on conversion rather than onward reading.
-- On non-commercial posts, the lead-in sentence before the related-posts list must be unique to that article. Do not reuse the same stock phrasing, canned curiosity line, or obvious template across the site.
-- Do not quote, parrot, or lightly rephrase the title in that lead-in. Write a clear article-specific bridge that nudges the reader toward the next useful clicks.
-- The related-posts list should use that custom lead-in line ending with a colon, then a standard Markdown list with entries like `- [Very specific anchor text](/target-slug)`.
-- Do not default to the destination post's exact title as the anchor text. Rewrite anchors so they fit the current article's context, stay accurate, and make the reason to click immediately clear.
-- Treat each anchor like the reader's next sensible click from this page. It should surface the next tension, decision, or payoff, not read like a pasted catalog title.
-- Keep the wording plain enough that the reader instantly understands why that link matters. Curiosity is useful, but not at the cost of clarity.
+- On non-commercial posts, the related-posts block should use a custom article-specific lead-in sentence ending with a colon, then a standard Markdown list such as `- [Very specific anchor text](/target-slug)`.
+- Do not quote or lightly rephrase the title in that lead-in.
+- Do not default to the destination post's exact title as anchor text. Rewrite anchors so they fit the current article's context, stay accurate, and make the reason to click immediately clear.
+- Keep anchor wording plain enough that the reader instantly understands why the link matters.
 - Add only the number of recommendations the topic can support on non-commercial posts: usually 3 or more, sometimes more, with a hard cap of 10. Choose them with editorial judgment based on what a reader would genuinely want next, not by category matching alone. You do not need to fully read every recommended post.
 - Keep visible content consistent with frontmatter and any structured data.
 - Any image used in the post should be hosted on Cloudflare Images rather than hotlinked from third parties.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,15 +1,15 @@
 # benjamincrozat.com
 
-This repo is my personal blog about web developent.
+This repo is my personal blog about web development.
 
 ## Development workflow
 
 - `composer setup`
 - `composer dev`
-- Serve the project using `php artisan serve`, but on another port.
-- Commit every change you make. Be as granular as possible.
-- Create a PR for the active branch as soon as it is ready to publish, and keep that PR up to date as more changes land on the branch.
-- When you have to commit, start the message with a short summary (10 words, tops). Then, add a detailed description of the changes (use lists to make it easier to read).
+- Serve the project with `php artisan serve` on a non-default port.
+- Commit every change you make, as granularly as practical.
+- Open a PR once the branch is ready to publish, and keep it updated as more changes land.
+- Commit messages should start with a short summary of 10 words or fewer, followed by a detailed list of changes.
 
 ## Worktrees
 
@@ -19,16 +19,16 @@ This repo is my personal blog about web developent.
   - `vendor`
   - `node_modules`
   - `public/build`
-- In this repo, the primary local checkout is typically `/Users/benjamin/Sites/blog-v5`. If a fresh worktree is missing the files above, link them from there instead of reinstalling everything by default.
+- The primary local checkout is usually `/Users/benjamin/Sites/blog-v5`. Link missing runtime files from there instead of reinstalling by default.
 - After wiring a fresh worktree, confirm it boots with `php artisan about --only=environment` before running `pint`, `phpstan`, or `pest`.
-- `https://blog-v5.test` may still serve the primary checkout rather than the new worktree. If you need to verify branch-specific changes and `blog-v5.test` is not serving the worktree, use `php artisan serve --host=127.0.0.1 --port=<port>` from that worktree and run the browser check against that port.
-- Post image generation uses `BLOG_PREVIEW_BASE_URL` when set, otherwise it falls back to `APP_URL`. For worktrees served through `php artisan serve`, give that worktree its own `.env` copy and set `APP_URL` to the matching `http://127.0.0.1:<port>` value before generating images.
+- `https://blog-v5.test` may still serve the primary checkout instead of the new worktree. When you need branch-specific browser checks, serve the worktree with `php artisan serve --host=127.0.0.1 --port=<port>` and test against that port.
+- Post image generation uses `BLOG_PREVIEW_BASE_URL` when set, otherwise it falls back to `APP_URL`. For a worktree served through `php artisan serve`, use a worktree-specific `.env` copy and set `APP_URL` to the matching `http://127.0.0.1:<port>` before generating images.
 - Keep worktree-only browser artifacts out of git. Clean up folders like `.playwright-cli/` and `output/` before finishing unless the user explicitly wants those files.
 
 ## Guardrails to keep in mind
 
-- **Do not overwrite user edits between reads.** If something changed since your last read, understand why and build on it. Or at least, ask the user for clarification.
-- **Never restore code that was deleted.** Like said above, if something was deleted, it was for a reason. Ask the user for clarification if necessary.
+- **Do not overwrite user edits between reads.** If something changed since your last read, understand why and build on it. Ask for clarification only when needed.
+- **Never restore deleted code.** If something was removed, assume it was intentional until you confirm otherwise.
 - **Keep changes small.** Implement the smallest change that solves the problem.
 - **No scope drift.** Do not refactor, restyle, or add “nice-to-haves” unless explicitly requested.
 - **Fix root causes.** Don’t band-aid symptoms.
@@ -36,28 +36,28 @@ This repo is my personal blog about web developent.
 - **State assumptions when needed.** If a requirement is underspecified, proceed with clearly labeled assumptions; only ask questions when blocked.
 - **Be concise and structured.** Prefer short, skimmable answers and concrete next actions over long explanations.
 - **Narrate tool usage briefly.** Before multi-step work or tool calls, give a 1–2 sentence “what I’m doing and why” update.
-- When executing a plan or a todo list, continue until it's complete. Don't ask for permission between tasks.
+- When executing a plan or todo list, continue until it is complete. Don’t ask for permission between tasks.
 
 ## How to verify your work
 
-- **Use your web browser to ensure quality of what's been prompted**: visuals and behavior.
-    - Set the resolution to 1512x982 when viewing the page in desktop mode
-    - Check that behavior goes according to the specs
-    - Take a screenshot and critique it to make sure it's visually correct according to the specs and your taste as a designer
+- **Use your web browser when the task affects visuals or behavior.**
+  - Set desktop checks to `1512x982`.
+  - Confirm the behavior matches the spec.
+  - Take a screenshot and critique the result for visual quality.
 - If you need credentials to log in, use what's in ./database/seeders/UserSeeder.php. The password is always `password`.
 - **Format**: `php vendor/bin/pint --parallel`
 - **Static analysis**: `php vendor/bin/phpstan analyse`
 - **Test**: `php vendor/bin/pest --parallel` (you can use `--filter` to run specific tests)
   - **Check coverage**: `php vendor/bin/pest --coverage --parallel` (you can also use `--filter` if necessary too)
-- For routine Markdown-only post edits in `resources/markdown/posts`, verification is lighter by default:
+- For routine Markdown-only post edits in `resources/markdown/posts`, use lighter verification by default:
   - required: `php artisan app:sync-posts`
   - optional only when warranted: browser checks, `pint`, `phpstan`, `pest`, or coverage
   - warranted means tricky rendering, embeds, custom HTML, unusual formatting, interactive behavior, a publishing-state change that needs confirmation, first-hand screenshots that materially help the reader, or an explicit user request
 
 ## Local skills
 
-- For Markdown-managed post work, follow the lighter verification rule above so `file-first-posts`, `post-writing`, and `seo-content` stay aligned with this file.
-- `file-first-posts`: Use when the task is about exporting, editing, publishing, or syncing Markdown-managed posts. File: `.agents/skills/file-first-posts/SKILL.md`
-- `framework-news-analysis`: Use when the task is about choosing and framing the strongest weekly news angle for a framework, library, tool, platform, or developer product. File: `.agents/skills/framework-news-analysis/SKILL.md`
-- `post-writing`: Use when the task is about drafting or revising publication-ready Markdown posts for the blog. File: `.agents/skills/post-writing/SKILL.md`
-- `seo-content`: Use when the task is about search intent, titles, snippets, internal links, AI-search visibility, or top-3 competitor analysis for blog posts and keywords. File: `.agents/skills/seo-content/SKILL.md`
+- For Markdown-managed post work, follow the lighter verification rule above so these skills stay aligned with this file.
+- `file-first-posts`: Export, edit, publish, or sync Markdown-managed posts. File: `.agents/skills/file-first-posts/SKILL.md`
+- `framework-news-analysis`: Choose and frame the strongest weekly news angle for a framework, library, tool, platform, or developer product. File: `.agents/skills/framework-news-analysis/SKILL.md`
+- `post-writing`: Draft or revise publication-ready Markdown posts for the blog. File: `.agents/skills/post-writing/SKILL.md`
+- `seo-content`: Handle search intent, titles, snippets, internal links, AI-search visibility, and top-3 competitor analysis for blog posts and keywords. File: `.agents/skills/seo-content/SKILL.md`


### PR DESCRIPTION
## Summary
- tighten AGENTS.md wording and remove small ambiguities
- align the local blog skills on the same Markdown-post workflow
- replace the outdated upload command in post-writing

## Testing
- git diff --check