### PR TITLE
Add SEO editorial plan

### DIFF
--- a/.agents/skills/file-first-posts/SKILL.md
+++ b/.agents/skills/file-first-posts/SKILL.md
@@ -23,7 +23,7 @@ Pair with `post-writing` when revising copy, and with `seo-content` when search 
 - When a post explains an interface, setup flow, settings page, terminal output, or before/after result, prefer creating original screenshots instead of leaving the visual outcome implied.
 - Skip screenshots only when they add no proof or clarity.
 - Give screenshot files descriptive names and useful alt text before upload.
-- Use UTC ISO-8601 timestamps for frontmatter dates such as `published_at` and `modified_at`.
+- Use UTC ISO-8601 timestamps with a trailing `Z` for frontmatter dates such as `published_at` and `modified_at`. Treat `Z` as the only canonical UTC format in this repo; do not use `+00:00`.
 - Publishing is changing `published_at` in the file, then running `php artisan app:sync-posts`.
 - If `categories` includes `news`, publish promptly, sync immediately after substantive edits, and only set `modified_at` when the article changed in a meaningful reporting way.
 - Only first-party, non-commercial, non-sponsored `news` posts should be treated as news-sitemap candidates.
@@ -48,10 +48,11 @@ Pair with `post-writing` when revising copy, and with `seo-content` when search 
    - hero image: `php artisan app:upload-post-image /absolute/path/to/cover.png --markdown=your-post.md`
    - inline image: `php artisan app:upload-post-image /absolute/path/to/step.png --alt="Describe the screenshot"` and paste the returned URL into the article body
    - if the post still has no featured image after writing it, generate one with `php artisan app:generate-post-image your-post-slug`
-4. If publishing state changes, update `published_at` in UTC.
-   - if this is a news post and you made a substantive reporting update, set `modified_at` in UTC before syncing
+4. If publishing state changes, update `published_at` in UTC with a trailing `Z`.
+   - if this is a news post and you made a substantive reporting update, set `modified_at` in UTC with a trailing `Z` before syncing
 5. Run `php artisan app:sync-posts`.
    - skip this extra sync only when the last action was `php artisan app:generate-post-image`, because that command already updates the Markdown file and runs `php artisan app:sync-posts` for you
+   - if `php artisan app:sync-posts` or `php artisan app:generate-post-image` rewrites timestamps to `+00:00`, normalize them back to the repo standard `Z` format before finishing
 6. Decide whether a browser check is needed:
    - skip it for routine Markdown-only edits when `php artisan app:sync-posts` succeeds
    - open the public page or Filament only for tricky rendering, embeds, custom HTML, unusual formatting, interactive behavior, or publishing changes that need confirmation

--- a/.agents/skills/post-writing/SKILL.md
+++ b/.agents/skills/post-writing/SKILL.md
@@ -19,6 +19,7 @@ Pair with `seo-content` for search intent, Discover/News judgment, titles, snipp
 - `author` must use the author's `github_login`.
 - `categories` must use category slugs.
 - `published_at`, `modified_at`, and `sponsored_at` use UTC ISO-8601 datetimes with a `Z` suffix or `null`.
+- Treat the `Z` suffix as the only canonical UTC format for frontmatter timestamps in this repo. Do not use `+00:00` when writing or normalizing dates.
 - `serp_title`, `serp_description`, `canonical_url`, `image_disk`, and `image_path` are nullable strings.
 - `serp_title` overrides the HTML `<title>` tag and `serp_description` overrides the meta description tag.
 - `is_commercial` must be `true` or `false`.
@@ -72,7 +73,7 @@ Pair with `seo-content` for search intent, Discover/News judgment, titles, snipp
 - Pick recommended posts that genuinely extend the topic for this exact reader journey. Use editorial judgment, not category matching or obvious heuristics. You do not need to fully read every recommended post before linking it, but you should believe the recommendation makes sense.
 - When creating or revising a post, add or improve natural internal links in the body wherever a reader would want the next step, not only in the closing list.
 - Verify links and commands when feasible. If something cannot be verified, tell the user outside the post copy.
-- When setting frontmatter timestamps, use UTC rather than the machine's local timezone.
+- When setting frontmatter timestamps, use UTC rather than the machine's local timezone, and write them with a trailing `Z`.
 - Skip browser-based validation for routine post-writing tasks. Only use it when the post has tricky rendering, embeds, custom HTML, unusual formatting, interactive behavior, the article needs first-hand screenshots that materially help the reader, or the user explicitly asks for a visual check.
 
 ## Common Shapes
@@ -110,3 +111,4 @@ Pair with `seo-content` for search intent, Discover/News judgment, titles, snipp
    - non-commercial posts have one up-to-date related-posts list with a custom lead-in that does not echo the title and anchor text that is contextual rather than a pasted destination title
    - commercial posts do not include a related-posts, read-next, or follow-up reading block
    - code and links support the nearby claim
+   - all frontmatter timestamps use the repo's canonical UTC format with a trailing `Z`, not `+00:00`

--- a/.agents/skills/seo-content/SKILL.md
+++ b/.agents/skills/seo-content/SKILL.md
@@ -37,6 +37,8 @@ Read these references as needed:
 - For CTR, prefer a concrete outcome, strong query match, and a clear differentiator over clever phrasing.
 - As a soft title heuristic, aim for roughly 40-60 characters or 6-9 words when possible. Break that range when extra specificity meaningfully improves relevance or trust.
 - Front-load the primary query match and main payoff early in the title, because the start of the title is the most consistently visible part.
+- For function-led or helper-led tutorials, prefer natural task-led titles over bare keyword labels. A good pattern is `How to <outcome> in <language> with <function>()` when the function name adds clarity without making the title stiff.
+- Do not force an exact-match head term into the visible title if it makes the title read like a search query. Keep the search intent intact, but write for humans first.
 - For custom descriptions, put the main benefit and query match in the first ~120 characters. A one-sentence summary often lands around 140-160 characters, but clarity matters more than hitting a count.
 - Questions are not an automatic CTR win. Positive, specific wording can help, but only when it stays natural and accurate.
 - Avoid cheap CTR bait: fake urgency, fake freshness, unsupported numbers, emoji gimmicks, or all-caps unless the query and vertical clearly support them.

--- a/resources/markdown/posts/php-implode.md
+++ b/resources/markdown/posts/php-implode.md
@@ -1,6 +1,6 @@
 ---
 id: "01KKV8GGB19F5CZ69PP32W1YRR"
-title: "How to join array values into a string in PHP"
+title: "How to join array values in PHP with implode()"
 slug: "php-implode"
 author: "benjamincrozat"
 description: "Use PHP implode() to join array values into strings, choose the right separator, handle associative arrays, and avoid the edge cases that trip people up."

--- a/resources/markdown/posts/php-implode.md
+++ b/resources/markdown/posts/php-implode.md
@@ -1,0 +1,280 @@
+---
+id: "01KKV8GGB19F5CZ69PP32W1YRR"
+title: "PHP implode(): join array values into strings safely"
+slug: "php-implode"
+author: "benjamincrozat"
+description: "Use PHP implode() to join array values into strings, choose the right separator, handle associative arrays, and avoid the edge cases that trip people up."
+categories:
+  - "php"
+published_at: null
+modified_at: null
+serp_title: null
+serp_description: null
+canonical_url: ""
+is_commercial: false
+image_disk: "cloudflare-images"
+image_path: "images/posts/generated/php-implode.png"
+sponsored_at: null
+---
+## Introduction
+
+**Use [`implode()`](https://www.php.net/implode) when you need to turn an array into a string.**
+
+It joins the array values with a separator you choose, which makes it perfect for comma-separated lists, CSS class strings, SQL fragments, and any other "array to text" job.
+
+Here is the fastest example:
+
+```php
+$tags = ['php', 'laravel', 'mysql'];
+
+echo implode(', ', $tags);
+
+// php, laravel, mysql
+```
+
+The two rules worth remembering are simple:
+
+- `implode()` joins **values**, not keys.
+- If your array contains `null`, nested arrays, or values you still need to format, clean those first.
+
+## How to use `implode()` in PHP
+
+The current signature is:
+
+```php
+implode(string $separator, array $array): string
+implode(array $array): string
+```
+
+You can pass the separator and the array, or pass the array alone if you want the values concatenated with no separator at all.
+
+```php
+echo implode('-', ['2026', '03', '16']);
+// 2026-03-16
+
+echo implode(['P', 'H', 'P']);
+// PHP
+```
+
+`join()` is just an alias of [`implode()`](https://www.php.net/implode), but `implode()` is the clearer name and the one most PHP developers expect to see.
+
+## When `implode()` is the right tool
+
+Reach for `implode()` when you already have the pieces in an array and your next step is to render them as one string.
+
+Typical examples:
+
+- show tags or categories separated by commas
+- build a space-separated CSS class list
+- join path segments with `/`
+- turn a list of formatted values into SQL or log output
+
+If you need the reverse operation, use [explode()](/php-explode) to split a string into an array.
+
+## Practical examples of `implode()`
+
+### Join a simple list with commas
+
+```php
+$frameworks = ['Laravel', 'Symfony', 'CodeIgniter'];
+
+echo implode(', ', $frameworks);
+
+// Laravel, Symfony, CodeIgniter
+```
+
+This is the most common use case: take an array of values and render a readable list.
+
+### Build a CSS class string
+
+This pattern shows up everywhere in PHP templates:
+
+```php
+$classes = array_filter([
+    'btn',
+    'btn-primary',
+    $isDisabled ? 'opacity-50' : null,
+    $hasError ? 'border-red-500' : null,
+]);
+
+echo implode(' ', $classes);
+```
+
+If `$isDisabled` is `true` and `$hasError` is `false`, the output is:
+
+```php
+btn btn-primary opacity-50
+```
+
+Filtering first matters here because otherwise `null` values become empty strings. If you do this kind of cleanup often, [array_filter()](/php-array-filter) is worth keeping nearby.
+
+### Add quotes around every value before joining
+
+Sometimes the array is almost ready, but each item needs a small transformation first.
+
+```php
+$columns = ['name', 'email', 'created_at'];
+
+$quotedColumns = array_map(
+    static fn (string $column): string => "`{$column}`",
+    $columns,
+);
+
+echo implode(', ', $quotedColumns);
+
+// `name`, `email`, `created_at`
+```
+
+This is cleaner than manually concatenating inside a loop, and it makes the transformation step obvious.
+
+### Associative arrays: keys are ignored
+
+This catches a lot of people the first time:
+
+```php
+$user = [
+    'first_name' => 'Taylor',
+    'last_name' => 'Otwell',
+];
+
+echo implode(' ', $user);
+
+// Taylor Otwell
+```
+
+`implode()` joins only the values. It does not include the keys.
+
+If you need `key=value` pairs, format them first:
+
+```php
+$params = [
+    'page' => 2,
+    'sort' => 'latest',
+];
+
+$pairs = array_map(
+    static fn (string $key, string|int $value): string => "{$key}={$value}",
+    array_keys($params),
+    $params,
+);
+
+echo implode('&', $pairs);
+
+// page=2&sort=latest
+```
+
+For real query strings, [`http_build_query()`](https://www.php.net/http_build_query) is usually the better choice because it handles URL encoding for you.
+
+### An empty array returns an empty string
+
+```php
+$values = [];
+
+var_dump(implode(', ', $values));
+
+// string(0) ""
+```
+
+That behavior is useful, but it can hide missing data if you expected at least one value. If an empty result would be a bug, check the array first.
+
+## Common pitfalls and gotchas
+
+### The old parameter order is not supported in modern PHP
+
+Older PHP versions accepted the arguments in reverse order. Current PHP expects the separator first and the array second.
+
+```php
+$parts = ['a', 'b', 'c'];
+
+echo implode(', ', $parts);
+// a, b, c
+```
+
+If you reverse them in PHP 8+, you get a `TypeError`.
+
+### Nested arrays produce warnings and useless output
+
+`implode()` is for flat arrays of scalar values. If one item is itself an array, PHP will try to convert it to the string `"Array"` and emit a warning.
+
+```php
+$values = [['a'], ['b']];
+
+echo implode(', ', $values);
+
+// Warning: Array to string conversion
+// Array, Array
+```
+
+If your data is nested, flatten or transform it first.
+
+### `null` becomes an empty string
+
+This is another subtle one:
+
+```php
+$values = ['php', null, 'laravel'];
+
+echo implode(', ', $values);
+
+// php, , laravel
+```
+
+That extra gap is easy to miss. Filter out `null` values first if you do not want blank segments in the output.
+
+### Non-string scalars are cast to strings
+
+Integers, floats, and booleans are converted to strings automatically:
+
+```php
+$values = [1, true, 3.5, false];
+
+echo implode(', ', $values);
+
+// 1, 1, 3.5,
+```
+
+That can be convenient, but it is also a good reason to format values explicitly when the final output matters.
+
+### Omitting the separator is valid, but rarely the clearest option
+
+Passing only the array works:
+
+```php
+echo implode(['P', 'H', 'P']);
+// PHP
+```
+
+Still, when readability matters, I prefer passing the separator explicitly because it makes the output format obvious at a glance.
+
+## `implode()` vs `explode()`
+
+These two functions are easy to mix up, so here is the mental shortcut:
+
+| Function | Input | Output | Use it when |
+| --- | --- | --- | --- |
+| `implode()` | array | string | you want to join array values |
+| `explode()` | string | array | you want to split a string by a separator |
+
+Example:
+
+```php
+$tags = ['php', 'laravel', 'mysql'];
+
+$line = implode(', ', $tags);
+// php, laravel, mysql
+
+$again = explode(', ', $line);
+// ['php', 'laravel', 'mysql']
+```
+
+If you keep bouncing between arrays and strings, [explode()](/php-explode) and [`implode()`](https://www.php.net/implode) are a pair worth memorizing.
+
+## Conclusion
+
+`implode()` is the right tool when you already have an array and need one string back. The most important things to remember are that it joins values only, it returns an empty string for an empty array, and it works best when you clean or format the data first.
+
+If you are still shaping PHP data after this, these are the next reads I would keep open:
+
+- [Split strings into arrays cleanly with explode](/php-explode)
+- [Filter PHP arrays cleanly before you join them](/php-array-filter)
+- [Map array values first when each item needs formatting](/php-array-map)

--- a/resources/markdown/posts/php-implode.md
+++ b/resources/markdown/posts/php-implode.md
@@ -6,7 +6,7 @@ author: "benjamincrozat"
 description: "Use PHP implode() to join array values into strings, choose the right separator, handle associative arrays, and avoid the edge cases that trip people up."
 categories:
   - "php"
-published_at: null
+published_at: 2026-03-16T12:27:00Z
 modified_at: null
 serp_title: null
 serp_description: null

--- a/resources/markdown/posts/php-implode.md
+++ b/resources/markdown/posts/php-implode.md
@@ -1,6 +1,6 @@
 ---
 id: "01KKV8GGB19F5CZ69PP32W1YRR"
-title: "PHP implode(): join array values into strings safely"
+title: "How to join array values into a string in PHP"
 slug: "php-implode"
 author: "benjamincrozat"
 description: "Use PHP implode() to join array values into strings, choose the right separator, handle associative arrays, and avoid the edge cases that trip people up."

--- a/resources/markdown/posts/php-isset.md
+++ b/resources/markdown/posts/php-isset.md
@@ -1,0 +1,249 @@
+---
+id: "01KKVATPFZ56K502JRV6TNBENY"
+title: "How to use isset() in PHP without getting tripped up"
+slug: "php-isset"
+author: "benjamincrozat"
+description: "Use PHP isset() to check whether a variable or array key exists and is not null, and understand when empty(), ??, or array_key_exists() is the better fit."
+categories:
+  - "php"
+published_at: 2026-03-16T12:47:00+00:00
+modified_at: null
+serp_title: null
+serp_description: null
+canonical_url: ""
+is_commercial: false
+image_disk: "cloudflare-images"
+image_path: "images/posts/generated/php-isset.png"
+sponsored_at: null
+---
+## Introduction
+
+**Use [`isset()`](https://www.php.net/isset) when you want to know whether a variable or array key exists and is not `null`.**
+
+```php
+$user = ['name' => 'Ben'];
+
+var_dump(isset($user['name']));
+var_dump(isset($user['email']));
+
+// true
+// false
+```
+
+That sounds simple, but `isset()` is one of those PHP helpers that keeps causing confusion because it overlaps with [`empty()`](https://www.php.net/empty), `??`, and [`array_key_exists()`](https://www.php.net/array_key_exists).
+
+The most important rule is this:
+
+- `isset()` returns `false` when the value is missing
+- `isset()` also returns `false` when the value exists but is `null`
+
+That is why this article is really about choosing the right tool, not just memorizing one function.
+
+## What `isset()` actually checks
+
+`isset()` returns `true` only when the variable or array key exists **and** its value is not `null`.
+
+```php
+$data = [
+    'name' => 'Ben',
+    'email' => null,
+];
+
+var_dump(isset($data['name']));
+var_dump(isset($data['email']));
+var_dump(isset($data['missing']));
+
+// true
+// false
+// false
+```
+
+That makes it useful for optional input, nested array access, and any situation where `null` should count as “not available.”
+
+## Simple `isset()` examples
+
+### Check whether an array key is available
+
+```php
+$post = ['title' => 'Laravel tips'];
+
+if (isset($post['title'])) {
+    echo $post['title'];
+}
+```
+
+This is a common pattern when reading request data, config arrays, or decoded JSON.
+
+### Check nested keys without notices
+
+`isset()` is handy here because it does not complain when an intermediate key is missing:
+
+```php
+$data = [];
+
+var_dump(isset($data['user']['email']));
+
+// false
+```
+
+That is one reason it stayed popular for so long in older PHP code.
+
+### Check several values at once
+
+`isset()` can check multiple variables or keys in one call:
+
+```php
+$user = [
+    'name' => 'Ben',
+    'email' => 'ben@example.com',
+];
+
+var_dump(isset($user['name'], $user['email']));
+
+// true
+```
+
+If any one of them is missing or `null`, the whole result becomes `false`.
+
+## `isset()` vs `empty()`
+
+This is the comparison people usually need.
+
+`isset()` answers:
+
+> Does this exist and is it not `null`?
+
+`empty()` answers:
+
+> Does this look empty in a boolean sense?
+
+That means `empty()` treats `0`, `'0'`, `''`, `false`, `[]`, and `null` as empty.
+
+```php
+$values = [
+    'count' => 0,
+    'name' => '',
+    'flag' => false,
+];
+
+var_dump(isset($values['count']), empty($values['count']));
+var_dump(isset($values['name']), empty($values['name']));
+var_dump(isset($values['flag']), empty($values['flag']));
+
+// true, true
+// true, true
+// true, true
+```
+
+So if `0`, `''`, or `false` are valid values in your app, `empty()` is usually the wrong check.
+
+If that specific comparison is what you are dealing with, [this PHP array empty guide](/php-array-empty) is the better deep dive.
+
+## `isset()` vs `??`
+
+The null coalescing operator is often cleaner than `isset()` when your real goal is a fallback value.
+
+Instead of this:
+
+```php
+$name = isset($_GET['name']) ? $_GET['name'] : 'Unknown';
+```
+
+Prefer this:
+
+```php
+$name = $_GET['name'] ?? 'Unknown';
+```
+
+Both use the same basic semantics: missing or `null` means “use the fallback.”
+
+The difference is that `??` reads more clearly when you want a value, not just a boolean check.
+
+If that is the pattern you use most, [this null coalescing operator guide](/php-double-question-mark-null-coalescing-operator) pairs nicely with this article.
+
+## `isset()` vs `array_key_exists()`
+
+This is the most important distinction after `empty()`.
+
+If `null` is a meaningful value, `isset()` is not enough.
+
+```php
+$data = ['missing' => null];
+
+var_dump(isset($data['missing']));
+var_dump(array_key_exists('missing', $data));
+
+// false
+// true
+```
+
+So:
+
+- use `isset()` when `null` should count as missing
+- use `array_key_exists()` when you need to know whether the key exists even if its value is `null`
+
+This matters a lot when `null` is part of your business logic instead of just “not set yet.”
+
+## Practical examples
+
+### Form input where an empty string is still a real value
+
+```php
+$post = ['email' => ''];
+
+var_dump(isset($post['email']));
+var_dump(empty($post['email']));
+var_dump($post['email'] ?? 'fallback');
+
+// true
+// true
+// ""
+```
+
+This is a good illustration of the tradeoff:
+
+- `isset()` says the key is present
+- `empty()` says the value is empty
+- `??` returns the actual value because it is not `null`
+
+### Optional nested data
+
+```php
+$payload = [];
+
+$email = $payload['user']['email'] ?? null;
+```
+
+This is usually cleaner than wrapping a nested `isset()` check around an assignment.
+
+### Config values that should not treat `0` as missing
+
+```php
+$config = ['retry_count' => 0];
+
+if (isset($config['retry_count'])) {
+    echo $config['retry_count'];
+}
+```
+
+This works because `0` is not `null`, so `isset()` still returns `true`.
+
+## When `isset()` is the right choice
+
+Use `isset()` when all of these are true:
+
+- you need a yes-or-no check
+- missing and `null` should behave the same way
+- values like `0`, `false`, and `''` should still count as present
+
+If any of those assumptions is wrong, another tool is usually clearer.
+
+## Conclusion
+
+`isset()` is useful, but only when you are precise about what it means. It does not tell you whether a value is truthy or non-empty. It tells you whether something exists and is not `null`.
+
+If you are still sorting out these tiny PHP checks that cause bigger bugs than they should, these are the next reads I would keep open:
+
+- [Use `??` when a fallback value is the real goal](/php-double-question-mark-null-coalescing-operator)
+- [Check arrays the right way before you branch on them](/php-array-empty)
+- [Decode request or API data more safely in PHP](/php-json-decode)

--- a/resources/markdown/posts/php-json-decode.md
+++ b/resources/markdown/posts/php-json-decode.md
@@ -6,7 +6,7 @@ author: "benjamincrozat"
 description: "Decode JSON in PHP with json_decode(), choose arrays vs objects, catch errors with JSON_THROW_ON_ERROR, and avoid null, depth, and bigint surprises."
 categories:
   - "php"
-published_at: null
+published_at: 2026-03-16T12:28:00Z
 modified_at: null
 serp_title: null
 serp_description: null

--- a/resources/markdown/posts/php-json-decode.md
+++ b/resources/markdown/posts/php-json-decode.md
@@ -1,6 +1,6 @@
 ---
 id: "01KKV90580W2NP6VWBSYGZQDSE"
-title: "PHP json_decode(): practical examples and safer defaults"
+title: "How to decode JSON in PHP with json_decode()"
 slug: "php-json-decode"
 author: "benjamincrozat"
 description: "Decode JSON in PHP with json_decode(), choose arrays vs objects, catch errors with JSON_THROW_ON_ERROR, and avoid null, depth, and bigint surprises."

--- a/resources/markdown/posts/php-json-decode.md
+++ b/resources/markdown/posts/php-json-decode.md
@@ -1,0 +1,310 @@
+---
+id: "01KKV90580W2NP6VWBSYGZQDSE"
+title: "PHP json_decode(): practical examples and safer defaults"
+slug: "php-json-decode"
+author: "benjamincrozat"
+description: "Decode JSON in PHP with json_decode(), choose arrays vs objects, catch errors with JSON_THROW_ON_ERROR, and avoid null, depth, and bigint surprises."
+categories:
+  - "php"
+published_at: null
+modified_at: null
+serp_title: null
+serp_description: null
+canonical_url: ""
+is_commercial: false
+image_disk: "cloudflare-images"
+image_path: "images/posts/generated/php-json-decode.png"
+sponsored_at: null
+---
+## Introduction
+
+**Use [`json_decode()`](https://www.php.net/json_decode) when you need to turn a JSON string into a PHP value.**
+
+For most API payloads, the safest practical default is:
+
+```php
+$data = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+```
+
+That gives you associative arrays instead of objects, and it throws a `JsonException` when the JSON is invalid instead of quietly returning `null`.
+
+Here is a real example:
+
+```php
+$json = '{"name":"Ben","roles":["admin","editor"]}';
+
+$data = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+
+echo $data['name'];
+echo $data['roles'][0];
+
+// Ben
+// admin
+```
+
+The confusing part is that `json_decode()` is flexible enough to return arrays, objects, strings, numbers, booleans, or `null`. This guide focuses on the choices and edge cases that actually trip people up.
+
+## How to use `json_decode()` in PHP
+
+The signature looks like this:
+
+```php
+json_decode(
+    string $json,
+    ?bool $associative = null,
+    int $depth = 512,
+    int $flags = 0
+): mixed
+```
+
+The four arguments that matter are:
+
+- `$json`: the JSON string you want to decode
+- `$associative`: `true` for associative arrays, `false` for objects
+- `$depth`: the maximum nesting depth
+- `$flags`: options such as `JSON_THROW_ON_ERROR` and `JSON_BIGINT_AS_STRING`
+
+The PHP manual also notes that [`json_decode()`](https://www.php.net/json_decode) only works with UTF-8 encoded strings.
+
+## The best default for most apps
+
+If you are decoding JSON from an API, a queue, a webhook, or a config-like payload, this is a strong default:
+
+```php
+try {
+    $data = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+} catch (JsonException $e) {
+    report($e);
+}
+```
+
+Why this version?
+
+- `true` gives you associative arrays, which are often simpler to inspect and transform in PHP
+- `JSON_THROW_ON_ERROR` avoids silent failures
+- `512` is the normal default depth, and being explicit makes the call easier to read later
+
+If you only need to check whether JSON is valid and do not need the decoded result yet, [`json_validate()`](/validate-json-in-php-with-json-validate) is a better fit.
+
+## Associative arrays vs objects
+
+This is the first thing most developers stumble over.
+
+### Decode JSON objects as PHP objects
+
+If you omit the second argument, JSON objects are returned as `stdClass` objects by default:
+
+```php
+$json = '{"name":"Ben","roles":["admin","editor"]}';
+
+$data = json_decode($json);
+
+echo $data->name;
+echo $data->roles[0];
+
+// Ben
+// admin
+```
+
+This is fine if you prefer property access or you are passing the decoded value into code that expects objects.
+
+### Decode JSON objects as associative arrays
+
+If you pass `true` as the second argument, JSON objects become associative arrays:
+
+```php
+$json = '{"name":"Ben","roles":["admin","editor"]}';
+
+$data = json_decode($json, true);
+
+echo $data['name'];
+echo $data['roles'][0];
+
+// Ben
+// admin
+```
+
+This is usually the easier option when you need to merge, filter, map, or reshape the data with normal PHP array functions.
+
+If that is how you usually work, [array_map()](/php-array-map) and [array_filter()](/php-array-filter) pair nicely with `json_decode()`.
+
+### Which one should you pick?
+
+Here is the short version:
+
+| Output style | Good default when | Access style |
+| --- | --- | --- |
+| object | you want property access or object-like semantics | `$data->name` |
+| associative array | you want to transform data with PHP array functions | `$data['name']` |
+
+What matters most is being explicit. Do not make future-you guess whether the result is an object or an array.
+
+## Common `json_decode()` examples
+
+### Decode a JSON list
+
+JSON arrays already decode to PHP arrays:
+
+```php
+$json = '["php","laravel","mysql"]';
+
+$data = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+
+print_r($data);
+
+// ['php', 'laravel', 'mysql']
+```
+
+Even if you pass `false`, the outer JSON array still becomes a PHP array. The `associative` argument mainly changes how JSON **objects** are handled.
+
+### Decode JSON into an object graph
+
+Sometimes object access reads a little better:
+
+```php
+$json = '{"user":{"name":"Ben","role":"admin"}}';
+
+$data = json_decode($json, false, 512, JSON_THROW_ON_ERROR);
+
+echo $data->user->role;
+
+// admin
+```
+
+### Preserve large integers as strings
+
+This one matters more than people realize when the JSON contains IDs, invoice numbers, or anything that must not lose precision.
+
+```php
+$json = '{"number":12345678901234567890}';
+
+$default = json_decode($json, true);
+$safe = json_decode($json, true, 512, JSON_BIGINT_AS_STRING);
+
+var_dump($default['number']);
+var_dump($safe['number']);
+```
+
+Output:
+
+```php
+float(1.2345678901234567E+19)
+string(20) "12345678901234567890"
+```
+
+If exact digits matter, add `JSON_BIGINT_AS_STRING`.
+
+## Why did `json_decode()` return `null`?
+
+This is the most common debugging question around the function.
+
+There are two very different reasons:
+
+1. The JSON really is the literal `null`
+2. Decoding failed
+
+These two cases look the same if you are not using `JSON_THROW_ON_ERROR`.
+
+### Valid JSON literal `null`
+
+```php
+var_dump(json_decode('null'));
+
+// NULL
+```
+
+That is valid JSON, so the result is genuinely `null`.
+
+### Invalid JSON also returns `null` without the error flag
+
+```php
+$json = '{name: "Ben"}';
+
+var_dump(json_decode($json));
+var_dump(json_last_error_msg());
+
+// NULL
+// "Syntax error"
+```
+
+That is why `JSON_THROW_ON_ERROR` is such a good default: it removes the ambiguity.
+
+## Safer error handling with `JSON_THROW_ON_ERROR`
+
+Instead of checking `json_last_error()` after every call, let PHP throw a `JsonException` for you.
+
+```php
+try {
+    $data = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+} catch (JsonException $e) {
+    echo $e->getMessage();
+}
+```
+
+With invalid JSON, you get a real exception instead of a vague `null`.
+
+If you need a refresher on exception handling itself, [this PHP exceptions guide](/php-exceptions) is a good companion piece.
+
+## Common decoding failures and fixes
+
+### Single quotes and trailing commas are not valid JSON
+
+This is a classic source of confusion when JSON is hand-written:
+
+```php
+// Invalid JSON
+$json = "{'name':'Ben',}";
+```
+
+JSON requires double quotes around keys and string values, and it does not allow trailing commas.
+
+Valid version:
+
+```php
+$json = '{"name":"Ben"}';
+```
+
+### Depth errors
+
+The default depth is `512`, which is enough for normal payloads. If the nesting is deeper than the limit, decoding fails.
+
+```php
+$json = '{"items":[{"a":{"b":{"c":1}}}]}';
+
+var_dump(json_decode($json, true, 3));
+var_dump(json_last_error_msg());
+
+// NULL
+// "Maximum stack depth exceeded"
+```
+
+If you pass an invalid depth such as `0`, PHP throws a `ValueError` in PHP 8.0+.
+
+### Invalid UTF-8 input
+
+The PHP manual states that [`json_decode()`](https://www.php.net/json_decode) only works with UTF-8 strings. If the incoming payload is badly encoded, decoding can fail.
+
+The relevant flags from the JSON constants page are:
+
+- `JSON_INVALID_UTF8_IGNORE`
+- `JSON_INVALID_UTF8_SUBSTITUTE`
+
+Use them carefully. They can help when you are dealing with messy external data, but they also change the original input.
+
+## `json_decode()` vs `json_validate()`
+
+Use `json_decode()` when you need the parsed result.
+
+Use [`json_validate()`](/validate-json-in-php-with-json-validate) when you only need to know whether the string is valid JSON and want to avoid parsing it twice.
+
+That rule keeps the code both clearer and cheaper.
+
+## Conclusion
+
+`json_decode()` is straightforward once you make two decisions early: should JSON objects become arrays or objects, and do you want silent failures or exceptions? For most day-to-day PHP work, `json_decode($json, true, 512, JSON_THROW_ON_ERROR)` is a solid default.
+
+If you are still working through JSON handling after this, these are the next reads I would keep nearby:
+
+- [Encode PHP arrays as JSON without silent failures](/php-array-to-json)
+- [Validate JSON first when decoding would be wasted work](/validate-json-in-php-with-json-validate)
+- [Handle JsonException and other failures more cleanly](/php-exceptions)

--- a/resources/markdown/posts/php-string-contains.md
+++ b/resources/markdown/posts/php-string-contains.md
@@ -1,12 +1,12 @@
 ---
 id: "01KKV9G24MNK41XG6FFCD34FNJ"
-title: "PHP string contains: use str_contains() and strpos() safely"
+title: "How to check if a string contains something in PHP"
 slug: "php-string-contains"
 author: "benjamincrozat"
 description: "Check whether a PHP string contains a value with str_contains(), use strpos() safely on older PHP versions, and handle case sensitivity without false positives."
 categories:
   - "php"
-published_at: 2026-03-16T12:28:30Z
+published_at: 2026-03-16T12:28:30+00:00
 modified_at: null
 serp_title: null
 serp_description: null

--- a/resources/markdown/posts/php-string-contains.md
+++ b/resources/markdown/posts/php-string-contains.md
@@ -6,7 +6,7 @@ author: "benjamincrozat"
 description: "Check whether a PHP string contains a value with str_contains(), use strpos() safely on older PHP versions, and handle case sensitivity without false positives."
 categories:
   - "php"
-published_at: null
+published_at: 2026-03-16T12:28:30Z
 modified_at: null
 serp_title: null
 serp_description: null

--- a/resources/markdown/posts/php-string-contains.md
+++ b/resources/markdown/posts/php-string-contains.md
@@ -1,12 +1,12 @@
 ---
 id: "01KKV9G24MNK41XG6FFCD34FNJ"
-title: "How to check if a string contains something in PHP"
+title: "How to check if a string contains text in PHP"
 slug: "php-string-contains"
 author: "benjamincrozat"
 description: "Check whether a PHP string contains a value with str_contains(), use strpos() safely on older PHP versions, and handle case sensitivity without false positives."
 categories:
   - "php"
-published_at: 2026-03-16T12:28:30+00:00
+published_at: 2026-03-16T12:28:30Z
 modified_at: null
 serp_title: null
 serp_description: null

--- a/resources/markdown/posts/php-string-contains.md
+++ b/resources/markdown/posts/php-string-contains.md
@@ -1,0 +1,221 @@
+---
+id: "01KKV9G24MNK41XG6FFCD34FNJ"
+title: "PHP string contains: use str_contains() and strpos() safely"
+slug: "php-string-contains"
+author: "benjamincrozat"
+description: "Check whether a PHP string contains a value with str_contains(), use strpos() safely on older PHP versions, and handle case sensitivity without false positives."
+categories:
+  - "php"
+published_at: null
+modified_at: null
+serp_title: null
+serp_description: null
+canonical_url: ""
+is_commercial: false
+image_disk: "cloudflare-images"
+image_path: "images/posts/generated/php-string-contains.png"
+sponsored_at: null
+---
+## Introduction
+
+**If you are on PHP 8.0 or later, use [`str_contains()`](https://www.php.net/str_contains) to check whether one string contains another.**
+
+```php
+if (str_contains('Laravel Forge', 'Forge')) {
+    //
+}
+```
+
+That is the clearest answer for modern PHP.
+
+If you are on an older version, the fallback is [`strpos()`](https://www.php.net/strpos) with a strict comparison:
+
+```php
+if (strpos('Laravel Forge', 'Forge') !== false) {
+    //
+}
+```
+
+The strict comparison matters because `strpos()` returns `0` when the match starts at the beginning of the string, and `0` is easy to mistake for `false`.
+
+## The best way to check if a string contains something in PHP
+
+### PHP 8.0 and later: `str_contains()`
+
+PHP 8.0 introduced [`str_contains()`](https://www.php.net/str_contains), which returns a plain boolean.
+
+```php
+var_dump(str_contains('Laravel Forge', 'Forge'));
+var_dump(str_contains('Laravel Forge', 'forge'));
+
+// true
+// false
+```
+
+That is why it is the best default now: the intent is obvious, and there is no `0 !== false` edge case to remember.
+
+### Older PHP: `strpos() !== false`
+
+If you are supporting PHP 7 or older code, use `strpos()` with a strict comparison:
+
+```php
+var_dump(strpos('Laravel Forge', 'Lar'));
+var_dump(strpos('Laravel Forge', 'Forge'));
+var_dump(strpos('Laravel Forge', 'nope'));
+
+// 0
+// 8
+// false
+```
+
+This is the safe version:
+
+```php
+if (strpos('Laravel Forge', 'Lar') !== false) {
+    //
+}
+```
+
+This is the buggy version:
+
+```php
+if (strpos('Laravel Forge', 'Lar')) {
+    //
+}
+```
+
+The second example fails because `strpos()` returns `0`, and plain `if (0)` is falsy.
+
+## `str_contains()` vs `strpos()`
+
+Here is the practical difference:
+
+| Function | PHP version | Return value | Best use |
+| --- | --- | --- | --- |
+| `str_contains()` | PHP 8.0+ | `true` or `false` | modern contains checks |
+| `strpos()` | all supported PHP versions | position or `false` | older PHP or when you need the index |
+
+If you only need a yes/no answer, `str_contains()` is clearer.
+
+If you also need the position of the match, `strpos()` is still the right tool.
+
+```php
+$position = strpos('Laravel Forge', 'Forge');
+
+if ($position !== false) {
+    echo $position;
+}
+
+// 8
+```
+
+## Case-sensitive vs case-insensitive checks
+
+`str_contains()` is case-sensitive:
+
+```php
+var_dump(str_contains('Laravel Forge', 'forge'));
+
+// false
+```
+
+If you need a case-insensitive contains check, [`stripos()`](https://www.php.net/stripos) is the straightforward option:
+
+```php
+var_dump(stripos('Laravel Forge', 'forge') !== false);
+var_dump(stripos('Laravel Forge', 'LAR') !== false);
+
+// true
+// true
+```
+
+Use `stripos() !== false` with the same strict comparison rule as `strpos()`.
+
+## Practical examples
+
+### Check whether a URL contains a path segment
+
+```php
+$path = '/docs/laravel/forge';
+
+if (str_contains($path, '/forge')) {
+    echo 'Forge docs';
+}
+```
+
+If you are working with raw request paths, [this current URL path guide](/php-current-url-path) covers the safer way to get the path first.
+
+### Check for a tag or keyword in free text
+
+```php
+$text = 'Laravel Forge makes server provisioning easier.';
+
+if (str_contains($text, 'Forge')) {
+    echo 'Mentioned';
+}
+```
+
+### Check the start of a string on older PHP
+
+This is the classic `strpos()` trap:
+
+```php
+$text = 'Laravel Forge';
+
+var_dump(strpos($text, 'Laravel') !== false);
+
+// true
+```
+
+If you forget the strict comparison, that same check can fail because the match starts at position `0`.
+
+## Important edge cases
+
+### An empty needle matches every string
+
+This surprises people the first time they see it:
+
+```php
+var_dump(str_contains('Laravel Forge', ''));
+
+// true
+```
+
+An empty string is considered to be contained in every string, including another empty string.
+
+If an empty search term should count as invalid input in your app, validate it before checking.
+
+### `strpos()` can return `0`
+
+This is worth repeating because it causes so many bugs:
+
+```php
+var_dump(strpos('Laravel Forge', 'Lar'));
+
+// 0
+```
+
+`0` means "found at the beginning," not "not found."
+
+### Case-insensitive checks need a different function
+
+There is no built-in `str_icontains()` in PHP. For a case-insensitive contains check, use `stripos() !== false`.
+
+## What if you need to split or replace instead?
+
+Contains checks are often just the first step.
+
+- If you need to split a string once the separator is found, use [explode()](/php-explode).
+- If you need to replace part of the string, use [str_replace()](/php-str-replace).
+
+That keeps each function doing one clear job.
+
+## Conclusion
+
+For modern PHP, the answer is simple: use `str_contains()` when you want a true-or-false contains check. Use `strpos() !== false` only when you need to support older PHP or when the match position itself matters.
+
+If you are still shaping strings after that, these are the next reads I would keep open:
+
+- [Replace part of a string without reaching for regex](/php-str-replace)
+- [Split strings into arrays when a separator matters](/php-explode)
+- [Join array values back into one string cleanly](/php-implode)

--- a/resources/markdown/posts/php-substr.md
+++ b/resources/markdown/posts/php-substr.md
@@ -1,6 +1,6 @@
 ---
 id: "01KKV9RKMYRHHTXEKB0QEF4T9S"
-title: "PHP substr(): practical examples and edge cases"
+title: "How to get part of a string in PHP with substr()"
 slug: "php-substr"
 author: "benjamincrozat"
 description: "Use PHP substr() to extract part of a string, understand negative offsets and lengths, and know when mb_substr() is the safer choice."

--- a/resources/markdown/posts/php-substr.md
+++ b/resources/markdown/posts/php-substr.md
@@ -1,0 +1,238 @@
+---
+id: "01KKV9RKMYRHHTXEKB0QEF4T9S"
+title: "PHP substr(): practical examples and edge cases"
+slug: "php-substr"
+author: "benjamincrozat"
+description: "Use PHP substr() to extract part of a string, understand negative offsets and lengths, and know when mb_substr() is the safer choice."
+categories:
+  - "php"
+published_at: 2026-03-16T12:29:00+00:00
+modified_at: null
+serp_title: null
+serp_description: null
+canonical_url: ""
+is_commercial: false
+image_disk: "cloudflare-images"
+image_path: "images/posts/generated/php-substr.png"
+sponsored_at: null
+---
+## Introduction
+
+**Use [`substr()`](https://www.php.net/substr) when you need to extract part of a string in PHP.**
+
+```php
+echo substr('Laravel', 0, 4);
+
+// Lara
+```
+
+The function is simple once you know what the three arguments mean:
+
+- the string you start from
+- the offset where extraction begins
+- the optional length
+
+The confusing parts are usually negative offsets, negative lengths, and multibyte strings like `café` or `こんにちは`. That is what this guide focuses on.
+
+## How to use `substr()` in PHP
+
+The signature looks like this:
+
+```php
+substr(string $string, int $offset, ?int $length = null): string
+```
+
+What each argument does:
+
+- `$string`: the original string
+- `$offset`: where to start
+- `$length`: how many characters to keep
+
+If you omit the length, `substr()` returns everything from the offset to the end of the string.
+
+## Basic `substr()` examples
+
+### Get the first few characters
+
+```php
+echo substr('Laravel', 0, 4);
+
+// Lara
+```
+
+Start at position `0` and keep `4` characters.
+
+### Get everything after a position
+
+```php
+echo substr('Laravel', 4);
+
+// vel
+```
+
+This is useful when you know where the interesting part begins and you want the rest of the string.
+
+### Start from the end with a negative offset
+
+```php
+echo substr('Laravel', -3);
+
+// vel
+```
+
+A negative offset counts backward from the end of the string.
+
+## Negative lengths and offsets
+
+This is where most articles get vague. These are the rules that matter in practice.
+
+### Negative offset: start from the end
+
+```php
+echo substr('Laravel', -4, 3);
+
+// ave
+```
+
+`-4` means "start four characters from the end."
+
+### Negative length: stop before the end
+
+```php
+echo substr('Laravel', 0, -1);
+
+// Larave
+```
+
+A negative length tells PHP to leave characters off the end.
+
+That makes `substr()` handy when you want to remove a file extension, trim a known suffix, or drop the last separator after building a string.
+
+### When the range does not make sense
+
+```php
+var_dump(substr('Laravel', 2, -20));
+
+// string(0) ""
+```
+
+If the requested slice falls outside the real string boundaries, PHP returns an empty string.
+
+## Common edge cases
+
+### Offset beyond the end returns an empty string
+
+```php
+var_dump(substr('Laravel', 20));
+
+// string(0) ""
+```
+
+This is not an error. You just get an empty string back.
+
+### Length longer than the remaining string is fine
+
+```php
+echo substr('Laravel', 2, 20);
+
+// ravel
+```
+
+PHP stops at the end of the string. It does not pad the result.
+
+### `substr()` can return an empty string, not `false`
+
+In current PHP, a lot of old examples still talk about `false` here. For ordinary string slicing, what you will usually see is an empty string when nothing can be extracted.
+
+That means `=== ''` is often the check you want if an empty result matters in your code.
+
+## `substr()` vs `mb_substr()`
+
+This is the most important practical warning in the whole article.
+
+`substr()` works on bytes, not user-visible characters. That is fine for plain ASCII text, but it breaks multibyte UTF-8 strings.
+
+### ASCII works as expected
+
+```php
+echo substr('Laravel', 0, 3);
+
+// Lar
+```
+
+### Multibyte text can break
+
+```php
+var_dump(substr('café', 0, 4));
+var_dump(mb_substr('café', 0, 4));
+
+// string(4) "caf�"
+// string(5) "café"
+```
+
+The same problem shows up even more clearly with non-Latin scripts:
+
+```php
+var_dump(substr('こんにちは', 0, 3));
+var_dump(mb_substr('こんにちは', 0, 3));
+
+// string(3) "こ"
+// string(9) "こんに"
+```
+
+If the input can contain UTF-8 text that users actually read, `mb_substr()` is usually the safer default.
+
+## Practical examples
+
+### Remove a known file extension
+
+```php
+$filename = 'report.pdf';
+
+echo substr($filename, 0, -4);
+
+// report
+```
+
+This works because `.pdf` is four characters long.
+
+### Get the last part of a slug or identifier
+
+```php
+$slug = 'laravel-forge';
+
+echo substr($slug, -5);
+
+// forge
+```
+
+### Extract a prefix for quick matching
+
+```php
+$code = 'INV-2026-0042';
+
+echo substr($code, 0, 3);
+
+// INV
+```
+
+If your next step is checking whether that prefix exists rather than extracting it, [this string contains guide](/php-string-contains) is the better fit.
+
+## `substr()` vs related functions
+
+- Use `substr()` when you already know the position you want to cut at.
+- Use [strpos()](https://www.php.net/strpos) when you first need to find the position of something.
+- Use [explode()](/php-explode) when you are splitting by a separator.
+- Use [str_replace()](/php-str-replace) when you want to replace part of the string instead of extracting it.
+
+That keeps the code easier to read because each function has one clear job.
+
+## Conclusion
+
+`substr()` is the right tool when you need part of a string and you already know the offset. The main things to remember are that negative offsets count from the end, negative lengths stop before the end, and UTF-8 text is where `mb_substr()` usually becomes the safer choice.
+
+If you are still working through string handling after this, these are the next reads I would keep open:
+
+- [Check whether a string contains something without the old `strpos()` bug](/php-string-contains)
+- [Split strings into arrays when a separator matters](/php-explode)
+- [Join pieces back into one string cleanly](/php-implode)

--- a/resources/markdown/posts/php-substr.md
+++ b/resources/markdown/posts/php-substr.md
@@ -1,12 +1,12 @@
 ---
 id: "01KKV9RKMYRHHTXEKB0QEF4T9S"
-title: "How to get part of a string in PHP with substr()"
+title: "How to extract part of a string in PHP with substr()"
 slug: "php-substr"
 author: "benjamincrozat"
 description: "Use PHP substr() to extract part of a string, understand negative offsets and lengths, and know when mb_substr() is the safer choice."
 categories:
   - "php"
-published_at: 2026-03-16T12:29:00+00:00
+published_at: 2026-03-16T12:29:00Z
 modified_at: null
 serp_title: null
 serp_description: null

--- a/seo-editorial-plan.md
+++ b/seo-editorial-plan.md
@@ -42,7 +42,7 @@ This is the working SEO backlog for the next article batch. We should move throu
   - Visual plan: code/output examples and a decision table should be enough.
   - Why first: the SERP is split between two functions, which creates room for a cleaner decision guide.
 
-- [ ] `php substr`
+- [x] `php substr`
   - Angle: a practical substring guide, not a shallow function reference.
   - Must cover: positive offsets, negative offsets, length behavior, falsey-looking outputs, and when to switch to `mb_substr()`.
   - Visual plan: examples plus a compact behavior table.

--- a/seo-editorial-plan.md
+++ b/seo-editorial-plan.md
@@ -1,0 +1,202 @@
+# SEO editorial plan
+
+Last updated: March 16, 2026
+Source brief: `/Users/benjamin/Downloads/PLAN.md`
+
+This is the working SEO backlog for the next article batch. We should move through it from top to bottom unless fresh Search Console or SERP data changes the priority. Check an item only when the article is drafted, reviewed, synced, and ready to publish.
+
+## What is already working
+
+- Your strongest feeder pages are practical PHP and Laravel posts, not news.
+- The clearest opportunity is to beat reference-style results with better tutorials, sharper examples, version notes, and comparison guidance.
+- For package and framework topics, the winning angle is usually the task behind the tool, not the package name alone.
+
+## Definition of done for every article
+
+- Check the live Google US desktop SERP before drafting and review the top 3 organic results.
+- Verify version-sensitive claims with official docs, release notes, specs, or direct testing.
+- Draft at least 5 title options before choosing the final title.
+- Open with a clear payoff, then teach through practical examples rather than bare syntax.
+- Add screenshots, crops, diagrams, or comparison visuals only when they materially improve clarity or prove first-hand use.
+- Add strong internal links in the body and refresh the related-posts block.
+- Generate or upload the featured image once the copy is stable.
+- Run `php artisan app:sync-posts` when the article is ready.
+
+## Write first
+
+- [ ] `php implode`
+  - Angle: a practical "array to string" guide instead of a syntax reference.
+  - Must cover: separators, quoted output, associative-array caveats, empty arrays, and `implode()` vs `explode()`.
+  - Visual plan: code and output blocks should be enough unless a comparison table makes the tradeoffs clearer.
+  - Why first: the SERP is beatable after the manual because few results feel like the clearest real-world tutorial.
+
+- [ ] `php json_decode`
+  - Angle: a troubleshooting-first guide for decoding JSON safely in PHP.
+  - Must cover: associative arrays vs objects, exceptions, invalid JSON, depth, flags, and safe decoding patterns.
+  - Visual plan: no screenshots by default; use before/after outputs and error examples.
+  - Why first: the query has high confusion intent and most pages stop at syntax.
+
+- [ ] `php string contains`
+  - Angle: answer "how do I check if a string contains something in PHP?" with the right function for modern and older versions.
+  - Must cover: `str_contains()`, `strpos()` for older PHP, case sensitivity, and common mistakes.
+  - Visual plan: code/output examples and a decision table should be enough.
+  - Why first: the SERP is split between two functions, which creates room for a cleaner decision guide.
+
+- [ ] `php substr`
+  - Angle: a practical substring guide, not a shallow function reference.
+  - Must cover: positive offsets, negative offsets, length behavior, falsey-looking outputs, and when to switch to `mb_substr()`.
+  - Visual plan: examples plus a compact behavior table.
+  - Why first: many competing pages stay thin on multibyte handling and edge cases.
+
+- [ ] `php isset`
+  - Angle: make this the clearest `isset()` vs `empty()` vs `??` guide for everyday PHP.
+  - Must cover: arrays, forms, object properties, null values, undefined keys, and comparison-driven examples.
+  - Visual plan: no screenshots needed; code comparisons should carry the piece.
+  - Why first: searchers are usually confused and comparison-style content is more useful than the manual.
+
+- [ ] `php trim`
+  - Angle: explain how to clean user input and why whitespace bugs keep slipping through.
+  - Must cover: invisible whitespace, custom character masks, line breaks, Unicode gotchas, and why `trim()` sometimes appears not to work.
+  - Visual plan: use code plus visible output markers; no screenshots unless needed to show hidden characters more clearly.
+  - Why first: the SERP is relatively soft beyond the PHP manual.
+
+- [ ] `php date format`
+  - Angle: a practical formatting guide with copy-ready patterns.
+  - Must cover: `date()` vs `DateTimeImmutable::format()`, common patterns, escaping, timestamps, time zones, and when `date()` is not enough.
+  - Visual plan: a compact cheat sheet table is likely more useful than screenshots.
+  - Why first: most searchers want examples, not two separate manual pages.
+
+- [ ] `php array length`
+  - Angle: answer the question fast with `count()`, then explain the real edge cases.
+  - Must cover: normal arrays, multidimensional arrays, `COUNT_RECURSIVE`, `Countable` objects, and common misunderstandings.
+  - Visual plan: no screenshots; examples and small comparison blocks are enough.
+  - Why first: the top blog-style result looks beatable.
+
+- [ ] `php array push`
+  - Angle: show when `array_push()` is useful and when `$array[] = ...` is the better default.
+  - Must cover: single values, multiple values, readability, performance tradeoffs, and team-style guidance.
+  - Visual plan: code comparisons only.
+  - Why first: ranking pages explain syntax but rarely help readers pick the better pattern.
+
+- [ ] `php array_merge`
+  - Angle: a decision guide around `array_merge()` vs `+` vs the spread operator.
+  - Must cover: numeric keys, string keys, overwrite behavior, preserving keys, and real-world merge patterns.
+  - Visual plan: a behavior matrix will likely help more than screenshots.
+  - Why first: the SERP has strong comparison intent, but the current pages do not organize it cleanly.
+
+- [ ] `php string length`
+  - Angle: the clearest `strlen()` vs `mb_strlen()` explanation for modern PHP.
+  - Must cover: byte length vs character length, Unicode examples, multibyte bugs, and when to choose each function.
+  - Visual plan: side-by-side output examples and a quick rule-of-thumb box.
+  - Why first: the SERP looks unusually weak beyond the manual.
+
+- [ ] `laravel pivot table`
+  - Angle: an end-to-end many-to-many guide with realistic examples.
+  - Must cover: migrations, models, `belongsToMany`, extra pivot fields, `attach()`, `sync()`, `syncWithoutDetaching()`, and `updateExistingPivot()`.
+  - Visual plan: add a simple relationship diagram and consider screenshots only if the article includes a UI workflow.
+  - Why first: tutorial-style content already proves it can compete here if the example is concrete enough.
+
+## Write next
+
+- [ ] `php error_log`
+  - Angle: explain where PHP logs go and how to log useful custom messages without guessing.
+  - Must cover: Apache, Nginx, local dev, Docker gotchas, `php.ini`, custom paths, and practical debugging patterns.
+  - Visual plan: screenshots may help if we show log locations in a real environment; otherwise code and config examples are enough.
+
+- [ ] `php parse_url`
+  - Angle: a safe URL parsing guide built around real broken inputs.
+  - Must cover: missing schemes, relative URLs, query strings, `parse_str()`, validation, and extraction pitfalls.
+  - Visual plan: no screenshots needed.
+
+- [ ] `php round`
+  - Angle: explain rounding without leaving finance and precision traps unexplained.
+  - Must cover: precision, halves, rounding modes, float surprises, and money-related caveats.
+  - Visual plan: no screenshots; examples and edge-case tables should carry it.
+
+- [ ] `php fopen`
+  - Angle: a practical file-handling guide rather than a mode list.
+  - Must cover: modes, file creation behavior, relative vs absolute paths, read/write patterns, locking, and safer alternatives when relevant.
+  - Visual plan: no screenshots by default.
+
+- [ ] `php include`
+  - Angle: clarify `include`, `require`, `include_once`, and `require_once` with consequences that matter in production.
+  - Must cover: warnings vs fatal errors, duplicate loads, return values, and modern project guidance.
+  - Visual plan: no screenshots needed.
+
+- [ ] `laravel redis`
+  - Angle: use Redis in Laravel for concrete jobs instead of explaining Redis in the abstract.
+  - Must cover: cache, queues, sessions, rate limiting, local setup, config, and common production pitfalls.
+  - Visual plan: screenshots may help for Horizon, logs, or local tooling if those examples add proof.
+
+- [ ] `laravel subquery`
+  - Angle: show how to write readable subqueries with Laravel's query builder and Eloquent.
+  - Must cover: `selectSub()`, `joinSub()`, correlated subqueries, SQL equivalents, and refactoring examples.
+  - Visual plan: a before/after query comparison is more useful than screenshots.
+
+- [ ] `laravel seeder`
+  - Angle: explain when to use seeders, factories, or both in a real Laravel workflow.
+  - Must cover: realistic sample data, local setup, test data, idempotent seeding, and common mistakes.
+  - Visual plan: screenshots only if they improve a demo workflow materially.
+
+- [ ] `laravel dompdf`
+  - Angle: teach PDF generation through a concrete invoice or receipt build.
+  - Must cover: package install, Blade views, CSS limitations, images, downloads, streaming, and rendering gotchas.
+  - Visual plan: screenshots or output samples are likely worth it because the final artifact is visual.
+
+- [ ] `laravel hasmanythrough`
+  - Angle: teach one confusing relationship through one concrete example readers can map to their own app.
+  - Must cover: relationship setup, example schema, query usage, mental model, and common mistakes.
+  - Visual plan: include a relationship diagram.
+
+## Reframe before writing
+
+- [ ] `laravel blade`
+  - Better target: "How to use Blade templates in Laravel" or "Blade components, layouts, props, and slots."
+  - Execution note: do not chase the bare head term with a generic overview.
+
+- [ ] `laravel debugbar`
+  - Better target: "How to install Laravel Debugbar and keep it out of production."
+  - Execution note: treat the package name as partly navigational and win on the setup workflow.
+
+- [ ] `laravel octane`
+  - Better target: "When Laravel Octane helps, when it hurts, and how to set it up."
+  - Execution note: make this a decision guide, not a docs rewrite.
+
+- [ ] `laravel scout`
+  - Better target: "Laravel Scout with Meilisearch or Algolia, locally and in production."
+  - Execution note: focus on the task, not the ecosystem overview.
+
+## Later expansion
+
+- [ ] `502 bad gateway nginx`
+  - Angle: a diagnosis-first troubleshooting guide with logs, PHP-FPM, upstreams, timeouts, and a fix order.
+
+- [ ] `401 error`
+  - Angle: a practical troubleshooting guide only after the PHP and Laravel backlog is moving well.
+
+- [ ] `503 error`
+  - Angle: same broad web-ops play as above; lower priority than the PHP and Laravel core topics.
+
+- [ ] `error establishing a database connection`
+  - Angle: pursue later as a broad troubleshooting term once the current topical cluster is stronger.
+
+- [ ] `ssl handshake failed`
+  - Angle: tackle later with a clear environment-by-environment troubleshooting flow.
+
+- [ ] `nginx reverse proxy`
+  - Angle: expansion topic for later because it pulls the site slightly away from the current PHP and Laravel core.
+
+- [ ] `install docker ubuntu`
+  - Angle: later infrastructure play, not the next best move.
+
+- [ ] `certbot nginx`
+  - Angle: later systems tutorial once the main backlog is in better shape.
+
+- [ ] `docker compose volumes`
+  - Angle: later expansion topic if you decide to widen the site's systems coverage.
+
+## Operating assumptions
+
+- This backlog is for net-new editorial opportunities rather than the release and version pages already maintained on the site.
+- For Laravel package topics, we should target the task behind the package instead of the package name alone.
+- For PHP helper terms, the way to win is practical examples, edge cases, comparisons, and clearer decision-making than the reference pages offer.

--- a/seo-editorial-plan.md
+++ b/seo-editorial-plan.md
@@ -36,7 +36,7 @@ This is the working SEO backlog for the next article batch. We should move throu
   - Visual plan: no screenshots by default; use before/after outputs and error examples.
   - Why first: the query has high confusion intent and most pages stop at syntax.
 
-- [ ] `php string contains`
+- [x] `php string contains`
   - Angle: answer "how do I check if a string contains something in PHP?" with the right function for modern and older versions.
   - Must cover: `str_contains()`, `strpos()` for older PHP, case sensitivity, and common mistakes.
   - Visual plan: code/output examples and a decision table should be enough.

--- a/seo-editorial-plan.md
+++ b/seo-editorial-plan.md
@@ -30,7 +30,7 @@ This is the working SEO backlog for the next article batch. We should move throu
   - Visual plan: code and output blocks should be enough unless a comparison table makes the tradeoffs clearer.
   - Why first: the SERP is beatable after the manual because few results feel like the clearest real-world tutorial.
 
-- [ ] `php json_decode`
+- [x] `php json_decode`
   - Angle: a troubleshooting-first guide for decoding JSON safely in PHP.
   - Must cover: associative arrays vs objects, exceptions, invalid JSON, depth, flags, and safe decoding patterns.
   - Visual plan: no screenshots by default; use before/after outputs and error examples.

--- a/seo-editorial-plan.md
+++ b/seo-editorial-plan.md
@@ -48,7 +48,7 @@ This is the working SEO backlog for the next article batch. We should move throu
   - Visual plan: examples plus a compact behavior table.
   - Why first: many competing pages stay thin on multibyte handling and edge cases.
 
-- [ ] `php isset`
+- [x] `php isset`
   - Angle: make this the clearest `isset()` vs `empty()` vs `??` guide for everyday PHP.
   - Must cover: arrays, forms, object properties, null values, undefined keys, and comparison-driven examples.
   - Visual plan: no screenshots needed; code comparisons should carry the piece.

--- a/seo-editorial-plan.md
+++ b/seo-editorial-plan.md
@@ -24,7 +24,7 @@ This is the working SEO backlog for the next article batch. We should move throu
 
 ## Write first
 
-- [ ] `php implode`
+- [x] `php implode`
   - Angle: a practical "array to string" guide instead of a syntax reference.
   - Must cover: separators, quoted output, associative-array caveats, empty arrays, and `implode()` vs `explode()`.
   - Visual plan: code and output blocks should be enough unless a comparison table makes the tradeoffs clearer.


### PR DESCRIPTION
## Summary
- add  at the project root
- turn the imported editorial opportunity report into a checkbox backlog
- capture the angle, must-cover topics, and visual guidance for each planned article