### PR TITLE
Add visuals to Laravel articles

### DIFF
--- a/resources/markdown/posts/laravel-blade-components-layouts-props-slots.md
+++ b/resources/markdown/posts/laravel-blade-components-layouts-props-slots.md
@@ -6,7 +6,7 @@ author: "benjamincrozat"
 description: "Learn how to use Blade components in Laravel with layouts, props, and slots so your templates stay reusable instead of turning into copy-paste markup."
 categories:
   - "laravel"
-published_at: 2026-03-16T14:52:57+00:00
+published_at: 2026-03-16T14:52:57Z
 modified_at: null
 serp_title: null
 serp_description: null
@@ -291,6 +291,10 @@ Here is what this looks like together in a real page:
     </x-card>
 </x-layout>
 ```
+
+And here is the kind of rendered result that structure gives you:
+
+![Rendered example page using a Blade layout, alert component, and named slot](https://imagedelivery.net/hYERsDhHaFG137wdGnWeuA/images/posts/laravel-blade-components-rendered-example.png/public)
 
 That is the shape you want: layout for page shell, components for repeated UI, props for configuration, and slots for content regions.
 

--- a/resources/markdown/posts/laravel-hasmanythrough.md
+++ b/resources/markdown/posts/laravel-hasmanythrough.md
@@ -6,7 +6,7 @@ author: "benjamincrozat"
 description: "Learn how Laravel hasManyThrough works with one concrete example, including the relationship definition, custom keys, and when it is a better fit than manual joins."
 categories:
   - "laravel"
-published_at: 2026-03-16T14:49:40+00:00
+published_at: 2026-03-16T14:49:40Z
 modified_at: null
 serp_title: null
 serp_description: null
@@ -43,6 +43,10 @@ That means:
 ```text
 Project -> Environment -> Deployment
 ```
+
+Here is the relationship visually before we get into the code:
+
+![Diagram showing a project reaching deployments through environments in Laravel](https://imagedelivery.net/hYERsDhHaFG137wdGnWeuA/images/posts/laravel-hasmanythrough-project-environment-deployment.png/public)
 
 So from `Project`, you want:
 

--- a/resources/markdown/posts/laravel-pivot-table.md
+++ b/resources/markdown/posts/laravel-pivot-table.md
@@ -6,7 +6,7 @@ author: "benjamincrozat"
 description: "Learn how Laravel pivot tables work with a practical many-to-many example, including the migration, belongsToMany(), extra pivot fields, attach(), sync(), and updateExistingPivot()."
 categories:
   - "laravel"
-published_at: 2026-03-16T13:09:30+00:00
+published_at: 2026-03-16T13:09:30Z
 modified_at: null
 serp_title: null
 serp_description: null
@@ -35,6 +35,10 @@ role_user
 ```
 
 That is the mental model. The rest is just wiring it into Eloquent correctly.
+
+Here is the same relationship as a quick diagram, including the extra fields that belong on the pivot table itself:
+
+![Diagram of users and roles connected by a role_user pivot table in Laravel](https://imagedelivery.net/hYERsDhHaFG137wdGnWeuA/images/posts/laravel-pivot-table-relationship-diagram.png/public)
 
 This guide walks through one real example from start to finish:
 

--- a/resources/markdown/posts/laravel-redis.md
+++ b/resources/markdown/posts/laravel-redis.md
@@ -6,7 +6,7 @@ author: "benjamincrozat"
 description: "Learn how to use Redis in Laravel with practical setup steps and examples for cache, queues, sessions, rate limiting, and direct Redis commands."
 categories:
   - "laravel"
-published_at: 2026-03-16T13:14:03+00:00
+published_at: 2026-03-16T13:14:03Z
 modified_at: null
 serp_title: null
 serp_description: null
@@ -33,6 +33,10 @@ If you only remember one thing from this guide, make it this:
 > Use Redis in Laravel when you need fast shared state that should survive between requests.
 
 This walkthrough shows the real setup and the four jobs that matter most in day-to-day Laravel work.
+
+This is the simplest way to picture the role Redis plays in a Laravel app:
+
+![Diagram showing Laravel using Redis for cache, queues, sessions, and rate limiting](https://imagedelivery.net/hYERsDhHaFG137wdGnWeuA/images/posts/laravel-redis-cache-queue-session-rate-limit.png/public)
 
 ## When Redis makes sense in Laravel
 


### PR DESCRIPTION
## Summary
- add relationship diagrams to the Laravel pivot table and hasManyThrough articles
- add a Redis architecture diagram and a rendered Blade example screenshot
- normalize the touched frontmatter timestamps back to the repo's canonical Z format

## Verification
- php artisan about --only=environment
- php artisan app:sync-posts
- browser check on the updated article pages at 1512x982
- confirmed the uploaded inline images load inside each article body