### PR TITLE
Add markdown-backed developer tool catalog

### DIFF
--- a/app/Actions/Tools/SyncMarkdownTools.php
+++ b/app/Actions/Tools/SyncMarkdownTools.php
@@ -50,6 +50,13 @@ class SyncMarkdownTools
         return DB::transaction(function () use ($documents, $reviewPostsBySlug, $existingById) {
             $createdCount = 0;
             $updatedCount = 0;
+            $trackedIds = collect($documents)->pluck('id');
+
+            $deletedCount = Tool::query()
+                ->whereNotIn('source_uuid', $trackedIds)
+                ->delete();
+
+            $this->releaseReviewPostsThatAreChanging($documents, $reviewPostsBySlug->all(), $existingById->all());
 
             foreach ($documents as $document) {
                 $tool = $existingById[$document->id] ?? new Tool;
@@ -67,6 +74,7 @@ class SyncMarkdownTools
                     'has_free_trial' => $document->hasFreeTrial,
                     'is_open_source' => $document->isOpenSource,
                     'categories' => $document->categories,
+                    'image_disk' => $document->imageDisk,
                     'image_path' => $document->imagePath,
                     'review_post_id' => $document->reviewPostSlug
                         ? $reviewPostsBySlug[$document->reviewPostSlug]->getKey()
@@ -91,12 +99,6 @@ class SyncMarkdownTools
                     $updatedCount++;
                 }
             }
-
-            $trackedIds = collect($documents)->pluck('id');
-
-            $deletedCount = Tool::query()
-                ->whereNotIn('source_uuid', $trackedIds)
-                ->delete();
 
             return new SyncMarkdownToolsResult(
                 createdCount: $createdCount,
@@ -228,6 +230,32 @@ class SyncMarkdownTools
 
         if ([] !== $errors) {
             throw ToolMarkdownException::fromErrors($errors);
+        }
+    }
+
+    /**
+     * @param  array<int, ToolMarkdownDocument>  $documents
+     * @param  array<string, Post>  $reviewPostsBySlug
+     * @param  array<string, Tool>  $existingById
+     */
+    protected function releaseReviewPostsThatAreChanging(array $documents, array $reviewPostsBySlug, array $existingById) : void
+    {
+        foreach ($documents as $document) {
+            $existingTool = $existingById[$document->id] ?? null;
+
+            if (! $existingTool?->review_post_id) {
+                continue;
+            }
+
+            $desiredReviewPostId = $document->reviewPostSlug
+                ? $reviewPostsBySlug[$document->reviewPostSlug]->getKey()
+                : null;
+
+            if ($existingTool->review_post_id === $desiredReviewPostId) {
+                continue;
+            }
+
+            $existingTool->forceFill(['review_post_id' => null])->save();
         }
     }
 

--- a/app/Actions/Tools/SyncMarkdownTools.php
+++ b/app/Actions/Tools/SyncMarkdownTools.php
@@ -1,0 +1,238 @@
+<?php
+
+namespace App\Actions\Tools;
+
+use App\Models\Post;
+use App\Models\Tool;
+use Illuminate\Support\Str;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use App\Markdown\ToolMarkdownDocument;
+use App\Exceptions\ToolMarkdownException;
+
+/**
+ * Syncs canonical Markdown tool sources into the database read model.
+ */
+class SyncMarkdownTools
+{
+    public function handle(?string $path = null) : SyncMarkdownToolsResult
+    {
+        $path ??= (string) config('blog.markdown.tools_path');
+
+        if (! File::isDirectory($path)) {
+            throw ToolMarkdownException::fromErrors([
+                "[{$path}] Markdown tools directory does not exist.",
+            ]);
+        }
+
+        $documents = $this->loadDocuments($path);
+        $this->validateDocuments($documents);
+
+        $reviewPostsBySlug = Post::query()
+            ->whereIn('slug', collect($documents)->pluck('reviewPostSlug')->filter()->unique())
+            ->get()
+            ->keyBy('slug');
+
+        $this->validateReviewPosts($documents, $reviewPostsBySlug->all());
+
+        $existingById = Tool::query()
+            ->whereIn('source_uuid', collect($documents)->pluck('id'))
+            ->get()
+            ->keyBy('source_uuid');
+
+        $existingBySlug = Tool::query()
+            ->whereIn('slug', collect($documents)->pluck('slug'))
+            ->get()
+            ->keyBy('slug');
+
+        $this->validateSlugConflicts($documents, $existingById->all(), $existingBySlug->all());
+
+        return DB::transaction(function () use ($documents, $reviewPostsBySlug, $existingById) {
+            $createdCount = 0;
+            $updatedCount = 0;
+
+            foreach ($documents as $document) {
+                $tool = $existingById[$document->id] ?? new Tool;
+                $isNew = ! $tool->exists;
+
+                $tool->forceFill([
+                    'slug' => $document->slug,
+                    'name' => $document->name,
+                    'description' => $document->description,
+                    'content' => blank($document->body) ? null : $document->body,
+                    'website_url' => $document->websiteUrl,
+                    'outbound_url' => $document->outboundUrl,
+                    'pricing_model' => $document->pricingModel,
+                    'has_free_plan' => $document->hasFreePlan,
+                    'has_free_trial' => $document->hasFreeTrial,
+                    'is_open_source' => $document->isOpenSource,
+                    'categories' => $document->categories,
+                    'image_path' => $document->imagePath,
+                    'review_post_id' => $document->reviewPostSlug
+                        ? $reviewPostsBySlug[$document->reviewPostSlug]->getKey()
+                        : null,
+                    'published_at' => $document->publishedAt,
+                    'source_uuid' => $document->id,
+                    'source_path' => $document->relativePath,
+                    'source_hash' => $document->hash(),
+                ]);
+
+                $isDirty = $isNew || $tool->isDirty();
+
+                $tool->save();
+
+                if ($isNew) {
+                    $createdCount++;
+
+                    continue;
+                }
+
+                if ($isDirty) {
+                    $updatedCount++;
+                }
+            }
+
+            $trackedIds = collect($documents)->pluck('id');
+
+            $deletedCount = Tool::query()
+                ->whereNotIn('source_uuid', $trackedIds)
+                ->delete();
+
+            return new SyncMarkdownToolsResult(
+                createdCount: $createdCount,
+                updatedCount: $updatedCount,
+                deletedCount: $deletedCount,
+            );
+        });
+    }
+
+    /**
+     * @return array<int, ToolMarkdownDocument>
+     */
+    protected function loadDocuments(string $path) : array
+    {
+        $errors = [];
+        $documents = [];
+
+        $files = collect(File::allFiles($path))
+            ->filter(fn (\SplFileInfo $file) => 'md' === $file->getExtension())
+            ->sortBy(fn (\SplFileInfo $file) => $this->relativePath($path, $file->getPathname()))
+            ->values();
+
+        foreach ($files as $file) {
+            $relativePath = $this->relativePath($path, $file->getPathname());
+
+            try {
+                $documents[] = ToolMarkdownDocument::fromMarkdown(File::get($file->getPathname()), $relativePath);
+            } catch (ToolMarkdownException $exception) {
+                $errors[] = $exception->getMessage();
+            }
+        }
+
+        if ([] !== $errors) {
+            throw ToolMarkdownException::fromErrors($errors);
+        }
+
+        return $documents;
+    }
+
+    /**
+     * @param  array<int, ToolMarkdownDocument>  $documents
+     */
+    protected function validateDocuments(array $documents) : void
+    {
+        $errors = [];
+
+        foreach (['id', 'slug'] as $field) {
+            $duplicates = collect($documents)
+                ->groupBy(fn (ToolMarkdownDocument $document) => $document->{$field})
+                ->filter(fn ($items) => $items->count() > 1);
+
+            foreach ($duplicates as $value => $items) {
+                $errors[] = "Duplicate {$field} [{$value}] found in " . $items->pluck('relativePath')->implode(', ') . '.';
+            }
+        }
+
+        $reviewDuplicates = collect($documents)
+            ->filter(fn (ToolMarkdownDocument $document) => filled($document->reviewPostSlug))
+            ->groupBy(fn (ToolMarkdownDocument $document) => $document->reviewPostSlug)
+            ->filter(fn ($items) => $items->count() > 1);
+
+        foreach ($reviewDuplicates as $reviewPostSlug => $items) {
+            $errors[] = "Review post slug [{$reviewPostSlug}] is assigned in " . $items->pluck('relativePath')->implode(', ') . '.';
+        }
+
+        if ([] !== $errors) {
+            throw ToolMarkdownException::fromErrors($errors);
+        }
+    }
+
+    /**
+     * @param  array<int, ToolMarkdownDocument>  $documents
+     * @param  array<string, Post>  $reviewPostsBySlug
+     */
+    protected function validateReviewPosts(array $documents, array $reviewPostsBySlug) : void
+    {
+        $errors = [];
+
+        foreach ($documents as $document) {
+            if (blank($document->reviewPostSlug)) {
+                continue;
+            }
+
+            $reviewPost = $reviewPostsBySlug[$document->reviewPostSlug] ?? null;
+
+            if (! $reviewPost) {
+                $errors[] = "[{$document->relativePath}] Unknown review post slug [{$document->reviewPostSlug}].";
+
+                continue;
+            }
+
+            if (method_exists($reviewPost, 'trashed') && $reviewPost->trashed()) {
+                $errors[] = "[{$document->relativePath}] Review post slug [{$document->reviewPostSlug}] is trashed.";
+            }
+        }
+
+        if ([] !== $errors) {
+            throw ToolMarkdownException::fromErrors($errors);
+        }
+    }
+
+    /**
+     * @param  array<int, ToolMarkdownDocument>  $documents
+     * @param  array<string, Tool>  $existingById
+     * @param  array<string, Tool>  $existingBySlug
+     */
+    protected function validateSlugConflicts(array $documents, array $existingById, array $existingBySlug) : void
+    {
+        $errors = [];
+
+        foreach ($documents as $document) {
+            $toolById = $existingById[$document->id] ?? null;
+            $toolBySlug = $existingBySlug[$document->slug] ?? null;
+
+            if ($toolById && $toolBySlug && ! $toolBySlug->is($toolById)) {
+                $errors[] = "[{$document->relativePath}] Slug [{$document->slug}] already belongs to a different tool.";
+
+                continue;
+            }
+
+            if ($toolById) {
+                continue;
+            }
+
+            if ($toolBySlug && $toolBySlug->source_uuid !== $document->id) {
+                $errors[] = "[{$document->relativePath}] Slug [{$document->slug}] already belongs to source id [{$toolBySlug->source_uuid}].";
+            }
+        }
+
+        if ([] !== $errors) {
+            throw ToolMarkdownException::fromErrors($errors);
+        }
+    }
+
+    protected function relativePath(string $basePath, string $fullPath) : string
+    {
+        return ltrim(str_replace('\\', '/', Str::after($fullPath, rtrim($basePath, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR)), '/');
+    }
+}

--- a/app/Actions/Tools/SyncMarkdownToolsResult.php
+++ b/app/Actions/Tools/SyncMarkdownToolsResult.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Actions\Tools;
+
+/**
+ * Carries counters for Markdown tool synchronization runs.
+ */
+class SyncMarkdownToolsResult
+{
+    public function __construct(
+        public readonly int $createdCount,
+        public readonly int $updatedCount,
+        public readonly int $deletedCount,
+    ) {}
+}

--- a/app/Console/Commands/SyncToolsCommand.php
+++ b/app/Console/Commands/SyncToolsCommand.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use App\Actions\Tools\SyncMarkdownTools;
+use App\Exceptions\ToolMarkdownException;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+/**
+ * Synchronizes markdown tool files into the tools database read model.
+ */
+#[AsCommand(
+    name: 'app:sync-tools',
+    description: 'Sync markdown source tools into the database'
+)]
+class SyncToolsCommand extends Command
+{
+    public function handle(SyncMarkdownTools $syncMarkdownTools) : int
+    {
+        $directory = $this->resolveDirectory();
+
+        try {
+            $result = $syncMarkdownTools->handle($directory);
+        } catch (ToolMarkdownException $exception) {
+            foreach (explode("\n", $exception->getMessage()) as $line) {
+                $this->error($line);
+            }
+
+            return self::FAILURE;
+        }
+
+        $this->info(
+            "Synced tools: created={$result->createdCount}, updated={$result->updatedCount}, deleted={$result->deletedCount}."
+        );
+
+        return self::SUCCESS;
+    }
+
+    protected function resolveDirectory() : ?string
+    {
+        $directory = trim((string) $this->option('directory'));
+
+        return '' === $directory ? null : $directory;
+    }
+
+    protected function configure() : void
+    {
+        $this->addOption(
+            'directory',
+            null,
+            InputOption::VALUE_OPTIONAL,
+            'The markdown directory to synchronize',
+        );
+    }
+}

--- a/app/Enums/ToolPricingModel.php
+++ b/app/Enums/ToolPricingModel.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Enums;
+
+/**
+ * Defines the supported tool pricing models.
+ */
+enum ToolPricingModel : string
+{
+    case Free = 'free';
+    case Freemium = 'freemium';
+    case Paid = 'paid';
+
+    public function label() : string
+    {
+        return match ($this) {
+            self::Free => 'Free',
+            self::Freemium => 'Freemium',
+            self::Paid => 'Paid',
+        };
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public static function values() : array
+    {
+        return array_map(fn (self $case) => $case->value, self::cases());
+    }
+}

--- a/app/Exceptions/ToolMarkdownException.php
+++ b/app/Exceptions/ToolMarkdownException.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Exceptions;
+
+use RuntimeException;
+
+/**
+ * Reports invalid Markdown tool source data with actionable context.
+ */
+class ToolMarkdownException extends RuntimeException
+{
+    /**
+     * @param  array<int, string>  $errors
+     */
+    public static function fromErrors(array $errors) : self
+    {
+        $message = collect($errors)
+            ->prepend('Markdown tool validation failed:')
+            ->implode("\n");
+
+        return new self($message);
+    }
+
+    public static function forPath(string $relativePath, string $message) : self
+    {
+        return new self("[{$relativePath}] {$message}");
+    }
+}

--- a/app/Http/Controllers/Merchants/ShowMerchantController.php
+++ b/app/Http/Controllers/Merchants/ShowMerchantController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Merchants;
 
+use App\Models\Tool;
 use Illuminate\Support\Uri;
 use Illuminate\Http\Request;
 use App\Http\Controllers\Controller;
@@ -14,16 +15,20 @@ class ShowMerchantController extends Controller
 {
     public function __invoke(Request $request, string $slug) : RedirectResponse
     {
-        abort_if(
-            ! $merchantLink = collect(config('merchants'))
-                ->flatMap(function (array $items) {
-                    return collect($items)->map(
-                        fn (mixed $item) => $item['link'] ?? $item
-                    );
-                })
-                ->get($slug),
-            404
-        );
+        $toolLink = Tool::query()
+            ->published()
+            ->where('slug', $slug)
+            ->value('outbound_url');
+
+        $merchantLink = $toolLink ?: collect(config('merchants'))
+            ->flatMap(function (array $items) {
+                return collect($items)->map(
+                    fn (mixed $item) => $item['link'] ?? $item
+                );
+            })
+            ->get($slug);
+
+        abort_if(blank($merchantLink), 404);
 
         return redirect()->away(
             Uri::of($merchantLink)

--- a/app/Http/Controllers/Tools/ListToolsController.php
+++ b/app/Http/Controllers/Tools/ListToolsController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Tools;
 
+use App\Models\Tool;
 use Illuminate\View\View;
 use App\Http\Controllers\Controller;
 use App\Actions\BuildBreadcrumbSchema;
@@ -19,6 +20,12 @@ class ListToolsController extends Controller
         ];
 
         return view('tools.index', [
+            'tools' => Tool::query()
+                ->with('reviewPost')
+                ->published()
+                ->orderByDesc('published_at')
+                ->orderBy('name')
+                ->get(),
             'breadcrumbs' => $breadcrumbs,
             'breadcrumbSchema' => app(BuildBreadcrumbSchema::class)->handle($breadcrumbs),
         ]);

--- a/app/Markdown/ToolMarkdownDocument.php
+++ b/app/Markdown/ToolMarkdownDocument.php
@@ -61,6 +61,11 @@ class ToolMarkdownDocument
             throw ToolMarkdownException::forPath($relativePath, "Filename must match slug [{$slug}].");
         }
 
+        $imageDisk = static::expectNullableString($frontMatter, 'image_disk', $relativePath);
+        $imagePath = static::expectNullableString($frontMatter, 'image_path', $relativePath);
+
+        static::ensureValidImageSource($imageDisk, $imagePath, $relativePath);
+
         return new self(
             id: static::expectId($frontMatter, 'id', $relativePath),
             name: static::expectString($frontMatter, 'name', $relativePath),
@@ -73,8 +78,8 @@ class ToolMarkdownDocument
             hasFreeTrial: static::expectBool($frontMatter, 'has_free_trial', $relativePath),
             isOpenSource: static::expectBool($frontMatter, 'is_open_source', $relativePath),
             categories: static::expectCategories($categories, $relativePath),
-            imageDisk: static::expectNullableString($frontMatter, 'image_disk', $relativePath),
-            imagePath: static::expectNullableString($frontMatter, 'image_path', $relativePath),
+            imageDisk: $imageDisk,
+            imagePath: $imagePath,
             reviewPostSlug: static::expectNullableString($frontMatter, 'review_post_slug', $relativePath),
             publishedAt: static::expectNullableDate($frontMatter, 'published_at', $relativePath),
             body: $matches['body'],
@@ -374,6 +379,35 @@ class ToolMarkdownDocument
         }
 
         return $categories;
+    }
+
+    protected static function ensureValidImageSource(?string $imageDisk, ?string $imagePath, string $relativePath) : void
+    {
+        if (blank($imageDisk) && blank($imagePath)) {
+            return;
+        }
+
+        if (filled($imageDisk) && blank($imagePath)) {
+            throw ToolMarkdownException::forPath(
+                $relativePath,
+                'Front matter key [image_disk] requires [image_path] to be set.'
+            );
+        }
+
+        if (blank($imagePath)) {
+            return;
+        }
+
+        if (str_starts_with($imagePath, 'http://') || str_starts_with($imagePath, 'https://') || str_starts_with($imagePath, 'resources/')) {
+            return;
+        }
+
+        if (blank($imageDisk)) {
+            throw ToolMarkdownException::forPath(
+                $relativePath,
+                'Front matter key [image_path] requires [image_disk] unless it is an absolute URL or a resources/ asset.'
+            );
+        }
     }
 
     protected static function parseScalar(string $value) : string|bool|null

--- a/app/Markdown/ToolMarkdownDocument.php
+++ b/app/Markdown/ToolMarkdownDocument.php
@@ -1,0 +1,412 @@
+<?php
+
+namespace App\Markdown;
+
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+use App\Enums\ToolPricingModel;
+use App\Exceptions\ToolMarkdownException;
+
+/**
+ * Holds the canonical Markdown contract for a file-managed tool.
+ */
+class ToolMarkdownDocument
+{
+    /**
+     * @param  array<int, string>  $categories
+     */
+    public function __construct(
+        public readonly string $id,
+        public readonly string $name,
+        public readonly string $slug,
+        public readonly string $description,
+        public readonly string $websiteUrl,
+        public readonly string $outboundUrl,
+        public readonly ToolPricingModel $pricingModel,
+        public readonly bool $hasFreePlan,
+        public readonly bool $hasFreeTrial,
+        public readonly bool $isOpenSource,
+        public readonly array $categories,
+        public readonly ?string $imagePath,
+        public readonly ?string $reviewPostSlug,
+        public readonly ?CarbonImmutable $publishedAt,
+        public readonly string $body,
+        public readonly string $relativePath,
+    ) {}
+
+    public static function fromMarkdown(string $markdown, string $relativePath) : self
+    {
+        $markdown = static::normalizeLineEndings($markdown);
+
+        if (! preg_match('/\A---\n(?<frontmatter>.*?)\n---\n?(?<body>.*)\z/s', $markdown, $matches)) {
+            throw ToolMarkdownException::forPath($relativePath, 'Missing a valid front matter block.');
+        }
+
+        /** @var array<string, mixed> $frontMatter */
+        $frontMatter = static::parseFrontMatter($matches['frontmatter'], $relativePath);
+
+        static::ensureRequiredKeys($frontMatter, $relativePath);
+
+        /** @var array<int, string> $categories */
+        $categories = $frontMatter['categories'];
+        $slug = static::expectString($frontMatter, 'slug', $relativePath);
+
+        if ('md' !== pathinfo($relativePath, PATHINFO_EXTENSION)) {
+            throw ToolMarkdownException::forPath($relativePath, 'Source files must use the .md extension.');
+        }
+
+        if (pathinfo($relativePath, PATHINFO_FILENAME) !== $slug) {
+            throw ToolMarkdownException::forPath($relativePath, "Filename must match slug [{$slug}].");
+        }
+
+        return new self(
+            id: static::expectString($frontMatter, 'id', $relativePath),
+            name: static::expectString($frontMatter, 'name', $relativePath),
+            slug: $slug,
+            description: static::expectString($frontMatter, 'description', $relativePath, allowBlank: true),
+            websiteUrl: static::expectUrl($frontMatter, 'website_url', $relativePath),
+            outboundUrl: static::expectUrl($frontMatter, 'outbound_url', $relativePath),
+            pricingModel: static::expectPricingModel($frontMatter, 'pricing_model', $relativePath),
+            hasFreePlan: static::expectBool($frontMatter, 'has_free_plan', $relativePath),
+            hasFreeTrial: static::expectBool($frontMatter, 'has_free_trial', $relativePath),
+            isOpenSource: static::expectBool($frontMatter, 'is_open_source', $relativePath),
+            categories: static::expectCategories($categories, $relativePath),
+            imagePath: static::expectNullableString($frontMatter, 'image_path', $relativePath),
+            reviewPostSlug: static::expectNullableString($frontMatter, 'review_post_slug', $relativePath),
+            publishedAt: static::expectNullableDate($frontMatter, 'published_at', $relativePath),
+            body: $matches['body'],
+            relativePath: static::normalizeRelativePath($relativePath),
+        );
+    }
+
+    public function hash() : string
+    {
+        return hash('sha256', static::normalizeLineEndings($this->toMarkdown()));
+    }
+
+    public function toMarkdown() : string
+    {
+        $lines = [
+            'id: ' . static::formatScalar($this->id),
+            'name: ' . static::formatScalar($this->name),
+            'slug: ' . static::formatScalar($this->slug),
+            'description: ' . static::formatScalar($this->description),
+            'website_url: ' . static::formatScalar($this->websiteUrl),
+            'outbound_url: ' . static::formatScalar($this->outboundUrl),
+            'pricing_model: ' . static::formatScalar($this->pricingModel->value),
+            'has_free_plan: ' . static::formatBool($this->hasFreePlan),
+            'has_free_trial: ' . static::formatBool($this->hasFreeTrial),
+            'is_open_source: ' . static::formatBool($this->isOpenSource),
+            'categories:',
+            ...collect($this->categories)
+                ->map(fn (string $category) => '  - ' . static::formatScalar($category))
+                ->all(),
+            'image_path: ' . static::formatScalar($this->imagePath),
+            'review_post_slug: ' . static::formatScalar($this->reviewPostSlug),
+            'published_at: ' . static::formatDate($this->publishedAt),
+        ];
+
+        return "---\n" . implode("\n", $lines) . "\n---\n{$this->body}";
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected static function parseFrontMatter(string $frontMatter, string $relativePath) : array
+    {
+        $allowedKeys = [
+            'id',
+            'name',
+            'slug',
+            'description',
+            'website_url',
+            'outbound_url',
+            'pricing_model',
+            'has_free_plan',
+            'has_free_trial',
+            'is_open_source',
+            'categories',
+            'image_path',
+            'review_post_slug',
+            'published_at',
+        ];
+
+        $data = [];
+        $currentListKey = null;
+
+        foreach (explode("\n", $frontMatter) as $lineNumber => $line) {
+            if ('' === $line) {
+                continue;
+            }
+
+            if ($currentListKey && preg_match('/^\s*-\s*(?<value>.+)$/', $line, $matches)) {
+                /** @var array<int, mixed> $existing */
+                $existing = $data[$currentListKey];
+
+                try {
+                    $existing[] = static::parseScalar(trim($matches['value']));
+                } catch (\JsonException) {
+                    throw ToolMarkdownException::forPath(
+                        $relativePath,
+                        'Invalid quoted string in front matter on line ' . ($lineNumber + 1) . '.'
+                    );
+                }
+
+                $data[$currentListKey] = $existing;
+
+                continue;
+            }
+
+            $currentListKey = null;
+
+            if (! preg_match('/^(?<key>[a-z_]+):(?:\s(?<value>.*)|(?<empty>\s*))$/', $line, $matches)) {
+                throw ToolMarkdownException::forPath(
+                    $relativePath,
+                    'Invalid front matter syntax on line ' . ($lineNumber + 1) . '.'
+                );
+            }
+
+            $key = $matches['key'];
+
+            if (! in_array($key, $allowedKeys, true)) {
+                throw ToolMarkdownException::forPath($relativePath, "Unknown front matter key [{$key}].");
+            }
+
+            if ('categories' === $key && '' === trim((string) ($matches['value'] ?? ''))) {
+                $data[$key] = [];
+                $currentListKey = $key;
+
+                continue;
+            }
+
+            try {
+                $data[$key] = static::parseScalar(trim((string) ($matches['value'] ?? '')));
+            } catch (\JsonException) {
+                throw ToolMarkdownException::forPath(
+                    $relativePath,
+                    'Invalid quoted string for front matter key [' . $key . '].'
+                );
+            }
+        }
+
+        return $data;
+    }
+
+    /**
+     * @param  array<string, mixed>  $frontMatter
+     */
+    protected static function ensureRequiredKeys(array $frontMatter, string $relativePath) : void
+    {
+        $requiredKeys = [
+            'id',
+            'name',
+            'slug',
+            'description',
+            'website_url',
+            'outbound_url',
+            'pricing_model',
+            'has_free_plan',
+            'has_free_trial',
+            'is_open_source',
+            'categories',
+        ];
+
+        $missing = collect($requiredKeys)
+            ->reject(fn (string $key) => Arr::has($frontMatter, $key))
+            ->values()
+            ->all();
+
+        if ([] === $missing) {
+            return;
+        }
+
+        throw ToolMarkdownException::forPath(
+            $relativePath,
+            'Missing required front matter keys: ' . implode(', ', $missing) . '.'
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $frontMatter
+     */
+    protected static function expectString(array $frontMatter, string $key, string $relativePath, bool $allowBlank = false) : string
+    {
+        $value = $frontMatter[$key] ?? null;
+
+        if (! is_string($value) || (! $allowBlank && blank($value))) {
+            throw ToolMarkdownException::forPath(
+                $relativePath,
+                "Front matter key [{$key}] must be " . ($allowBlank ? 'a string.' : 'a non-empty string.')
+            );
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param  array<string, mixed>  $frontMatter
+     */
+    protected static function expectNullableString(array $frontMatter, string $key, string $relativePath) : ?string
+    {
+        $value = $frontMatter[$key] ?? null;
+
+        if (null === $value) {
+            return null;
+        }
+
+        if (! is_string($value)) {
+            throw ToolMarkdownException::forPath($relativePath, "Front matter key [{$key}] must be a string or null.");
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param  array<string, mixed>  $frontMatter
+     */
+    protected static function expectUrl(array $frontMatter, string $key, string $relativePath) : string
+    {
+        $value = static::expectString($frontMatter, $key, $relativePath);
+
+        if (! filter_var($value, FILTER_VALIDATE_URL)) {
+            throw ToolMarkdownException::forPath($relativePath, "Front matter key [{$key}] must be a valid URL.");
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param  array<string, mixed>  $frontMatter
+     */
+    protected static function expectPricingModel(array $frontMatter, string $key, string $relativePath) : ToolPricingModel
+    {
+        $value = static::expectString($frontMatter, $key, $relativePath);
+
+        return ToolPricingModel::tryFrom($value)
+            ?? throw ToolMarkdownException::forPath(
+                $relativePath,
+                'Front matter key [pricing_model] must be one of: ' . implode(', ', ToolPricingModel::values()) . '.'
+            );
+    }
+
+    /**
+     * @param  array<string, mixed>  $frontMatter
+     */
+    protected static function expectBool(array $frontMatter, string $key, string $relativePath) : bool
+    {
+        $value = $frontMatter[$key] ?? null;
+
+        if (! is_bool($value)) {
+            throw ToolMarkdownException::forPath($relativePath, "Front matter key [{$key}] must be a boolean.");
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param  array<string, mixed>  $frontMatter
+     */
+    protected static function expectNullableDate(array $frontMatter, string $key, string $relativePath) : ?CarbonImmutable
+    {
+        $value = $frontMatter[$key] ?? null;
+
+        if (null === $value) {
+            return null;
+        }
+
+        if (! is_string($value) || blank($value)) {
+            throw ToolMarkdownException::forPath($relativePath, "Front matter key [{$key}] must be an ISO-8601 datetime or null.");
+        }
+
+        try {
+            return CarbonImmutable::parse($value);
+        } catch (\Throwable) {
+            throw ToolMarkdownException::forPath(
+                $relativePath,
+                "Front matter key [{$key}] must be a valid datetime string."
+            );
+        }
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    protected static function expectCategories(mixed $value, string $relativePath) : array
+    {
+        if (! is_array($value)) {
+            throw ToolMarkdownException::forPath($relativePath, 'Front matter key [categories] must be a YAML list.');
+        }
+
+        if (collect($value)->contains(fn (mixed $category) => ! is_string($category) || blank($category))) {
+            throw ToolMarkdownException::forPath($relativePath, 'Front matter key [categories] must contain only non-empty strings.');
+        }
+
+        /** @var array<int, string> $categories */
+        $categories = collect($value)
+            ->values()
+            ->all();
+
+        if (count($categories) !== count(array_unique($categories))) {
+            throw ToolMarkdownException::forPath($relativePath, 'Front matter key [categories] cannot contain duplicates.');
+        }
+
+        return $categories;
+    }
+
+    protected static function parseScalar(string $value) : string|bool|null
+    {
+        if ('null' === $value) {
+            return null;
+        }
+
+        if ('true' === $value) {
+            return true;
+        }
+
+        if ('false' === $value) {
+            return false;
+        }
+
+        if (Str::startsWith($value, '"') && Str::endsWith($value, '"')) {
+            $decoded = json_decode($value, true, 512, JSON_THROW_ON_ERROR);
+
+            return is_string($decoded) ? $decoded : $value;
+        }
+
+        if (Str::startsWith($value, "'") && Str::endsWith($value, "'")) {
+            return str_replace("''", "'", substr($value, 1, -1));
+        }
+
+        return $value;
+    }
+
+    protected static function formatScalar(?string $value) : string
+    {
+        if (null === $value) {
+            return 'null';
+        }
+
+        return json_encode($value, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+    }
+
+    protected static function formatDate(?CarbonImmutable $value) : string
+    {
+        return $value?->toIso8601String() ?? 'null';
+    }
+
+    protected static function formatBool(bool $value) : string
+    {
+        return $value ? 'true' : 'false';
+    }
+
+    protected static function normalizeLineEndings(string $markdown) : string
+    {
+        return str_replace(["\r\n", "\r"], "\n", $markdown);
+    }
+
+    protected static function normalizeRelativePath(string $relativePath) : string
+    {
+        return ltrim(str_replace('\\', '/', $relativePath), '/');
+    }
+}

--- a/app/Markdown/ToolMarkdownDocument.php
+++ b/app/Markdown/ToolMarkdownDocument.php
@@ -28,6 +28,7 @@ class ToolMarkdownDocument
         public readonly bool $hasFreeTrial,
         public readonly bool $isOpenSource,
         public readonly array $categories,
+        public readonly ?string $imageDisk,
         public readonly ?string $imagePath,
         public readonly ?string $reviewPostSlug,
         public readonly ?CarbonImmutable $publishedAt,
@@ -61,7 +62,7 @@ class ToolMarkdownDocument
         }
 
         return new self(
-            id: static::expectString($frontMatter, 'id', $relativePath),
+            id: static::expectId($frontMatter, 'id', $relativePath),
             name: static::expectString($frontMatter, 'name', $relativePath),
             slug: $slug,
             description: static::expectString($frontMatter, 'description', $relativePath, allowBlank: true),
@@ -72,6 +73,7 @@ class ToolMarkdownDocument
             hasFreeTrial: static::expectBool($frontMatter, 'has_free_trial', $relativePath),
             isOpenSource: static::expectBool($frontMatter, 'is_open_source', $relativePath),
             categories: static::expectCategories($categories, $relativePath),
+            imageDisk: static::expectNullableString($frontMatter, 'image_disk', $relativePath),
             imagePath: static::expectNullableString($frontMatter, 'image_path', $relativePath),
             reviewPostSlug: static::expectNullableString($frontMatter, 'review_post_slug', $relativePath),
             publishedAt: static::expectNullableDate($frontMatter, 'published_at', $relativePath),
@@ -102,6 +104,7 @@ class ToolMarkdownDocument
             ...collect($this->categories)
                 ->map(fn (string $category) => '  - ' . static::formatScalar($category))
                 ->all(),
+            'image_disk: ' . static::formatScalar($this->imageDisk),
             'image_path: ' . static::formatScalar($this->imagePath),
             'review_post_slug: ' . static::formatScalar($this->reviewPostSlug),
             'published_at: ' . static::formatDate($this->publishedAt),
@@ -127,6 +130,7 @@ class ToolMarkdownDocument
             'has_free_trial',
             'is_open_source',
             'categories',
+            'image_disk',
             'image_path',
             'review_post_slug',
             'published_at',
@@ -247,6 +251,20 @@ class ToolMarkdownDocument
     /**
      * @param  array<string, mixed>  $frontMatter
      */
+    protected static function expectId(array $frontMatter, string $key, string $relativePath) : string
+    {
+        $value = static::expectString($frontMatter, $key, $relativePath);
+
+        if (! Str::isUlid($value)) {
+            throw ToolMarkdownException::forPath($relativePath, "Front matter key [{$key}] must be a valid ULID.");
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param  array<string, mixed>  $frontMatter
+     */
     protected static function expectNullableString(array $frontMatter, string $key, string $relativePath) : ?string
     {
         $value = $frontMatter[$key] ?? null;
@@ -316,6 +334,10 @@ class ToolMarkdownDocument
         }
 
         if (! is_string($value) || blank($value)) {
+            throw ToolMarkdownException::forPath($relativePath, "Front matter key [{$key}] must be an ISO-8601 datetime or null.");
+        }
+
+        if (! preg_match('/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/', $value)) {
             throw ToolMarkdownException::forPath($relativePath, "Front matter key [{$key}] must be an ISO-8601 datetime or null.");
         }
 

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -107,6 +107,11 @@ class Post extends Model implements Feedable
         return $this->hasOne(Link::class);
     }
 
+    public function reviewedTool() : HasOne
+    {
+        return $this->hasOne(Tool::class, 'review_post_id');
+    }
+
     public function formattedContent() : Attribute
     {
         return Attribute::make(

--- a/app/Models/Tool.php
+++ b/app/Models/Tool.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\ToolPricingModel;
+use Database\Factories\ToolFactory;
+use Illuminate\Support\Facades\Vite;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Attributes\Scope;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
+/**
+ * Represents a Markdown-managed developer tool.
+ */
+class Tool extends Model
+{
+    /** @use HasFactory<ToolFactory> */
+    use HasFactory;
+
+    protected function casts() : array
+    {
+        return [
+            'pricing_model' => ToolPricingModel::class,
+            'has_free_plan' => 'boolean',
+            'has_free_trial' => 'boolean',
+            'is_open_source' => 'boolean',
+            'categories' => 'array',
+            'published_at' => 'datetime',
+        ];
+    }
+
+    #[Scope]
+    protected function published(Builder $query) : void
+    {
+        $query
+            ->whereNotNull('published_at')
+            ->where('published_at', '<=', now());
+    }
+
+    public function reviewPost() : BelongsTo
+    {
+        return $this->belongsTo(Post::class, 'review_post_id');
+    }
+
+    public function imageUrl() : Attribute
+    {
+        return Attribute::make(function () {
+            if (blank($this->image_path)) {
+                return null;
+            }
+
+            if (str_starts_with($this->image_path, 'http://') || str_starts_with($this->image_path, 'https://')) {
+                return $this->image_path;
+            }
+
+            if (str_starts_with($this->image_path, 'resources/')) {
+                return Vite::asset($this->image_path);
+            }
+
+            return Storage::disk('cloudflare-images')->url($this->image_path);
+        })->shouldCache();
+    }
+
+    public function pricingLabel() : Attribute
+    {
+        return Attribute::make(
+            fn () => $this->pricing_model?->label(),
+        )->shouldCache();
+    }
+
+    public function hasReview() : bool
+    {
+        return null !== $this->review_post_id;
+    }
+}

--- a/app/Models/Tool.php
+++ b/app/Models/Tool.php
@@ -61,7 +61,11 @@ class Tool extends Model
                 return Vite::asset($this->image_path);
             }
 
-            return Storage::disk('cloudflare-images')->url($this->image_path);
+            if (blank($this->image_disk)) {
+                return null;
+            }
+
+            return Storage::disk($this->image_disk)->url($this->image_path);
         })->shouldCache();
     }
 

--- a/config/blog.php
+++ b/config/blog.php
@@ -3,6 +3,7 @@
 return [
     'markdown' => [
         'posts_path' => resource_path('markdown/posts'),
+        'tools_path' => resource_path('markdown/tools'),
     ],
     'preview_base_url' => env('BLOG_PREVIEW_BASE_URL'),
     'screenshot' => [

--- a/database/factories/ToolFactory.php
+++ b/database/factories/ToolFactory.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Post;
+use App\Models\Tool;
+use App\Enums\ToolPricingModel;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Tool>
+ */
+class ToolFactory extends Factory
+{
+    public function definition() : array
+    {
+        $slug = fake()->slug();
+
+        return [
+            'source_uuid' => (string) fake()->unique()->regexify('[0-9A-HJKMNP-TV-Z]{26}'),
+            'source_path' => "{$slug}.md",
+            'source_hash' => hash('sha256', $slug),
+            'slug' => $slug,
+            'name' => fake()->company(),
+            'description' => fake()->sentence(),
+            'content' => fake()->paragraph(),
+            'website_url' => fake()->url(),
+            'outbound_url' => fake()->url(),
+            'pricing_model' => fake()->randomElement(ToolPricingModel::cases()),
+            'has_free_plan' => fake()->boolean(),
+            'has_free_trial' => fake()->boolean(),
+            'is_open_source' => fake()->boolean(),
+            'categories' => [fake()->word()],
+            'image_path' => null,
+            'review_post_id' => null,
+            'published_at' => fake()->dateTimeBetween('-1 year', 'now'),
+        ];
+    }
+
+    public function withReview(?Post $post = null) : self
+    {
+        return $this->state(fn () => [
+            'review_post_id' => $post?->getKey() ?? Post::factory(),
+        ]);
+    }
+}

--- a/database/factories/ToolFactory.php
+++ b/database/factories/ToolFactory.php
@@ -31,6 +31,7 @@ class ToolFactory extends Factory
             'has_free_trial' => fake()->boolean(),
             'is_open_source' => fake()->boolean(),
             'categories' => [fake()->word()],
+            'image_disk' => null,
             'image_path' => null,
             'review_post_id' => null,
             'published_at' => fake()->dateTimeBetween('-1 year', 'now'),

--- a/database/migrations/2026_03_17_090000_create_tools_table.php
+++ b/database/migrations/2026_03_17_090000_create_tools_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    public function up() : void
+    {
+        Schema::create('tools', function (Blueprint $table) {
+            $table->id();
+            $table->char('source_uuid', 26)->unique();
+            $table->string('source_path');
+            $table->string('source_hash', 64);
+            $table->string('slug')->unique();
+            $table->string('name');
+            $table->text('description');
+            $table->text('content')->nullable();
+            $table->string('website_url');
+            $table->string('outbound_url');
+            $table->string('pricing_model');
+            $table->boolean('has_free_plan')->default(false);
+            $table->boolean('has_free_trial')->default(false);
+            $table->boolean('is_open_source')->default(false);
+            $table->json('categories');
+            $table->string('image_path')->nullable();
+            $table->foreignId('review_post_id')->nullable()->unique()->constrained('posts')->nullOnDelete();
+            $table->dateTime('published_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down() : void
+    {
+        Schema::dropIfExists('tools');
+    }
+};

--- a/database/migrations/2026_03_17_090000_create_tools_table.php
+++ b/database/migrations/2026_03_17_090000_create_tools_table.php
@@ -24,6 +24,7 @@ return new class extends Migration
             $table->boolean('has_free_trial')->default(false);
             $table->boolean('is_open_source')->default(false);
             $table->json('categories');
+            $table->string('image_disk')->nullable();
             $table->string('image_path')->nullable();
             $table->foreignId('review_post_id')->nullable()->unique()->constrained('posts')->nullOnDelete();
             $table->dateTime('published_at')->nullable();

--- a/database/migrations/2026_03_18_090000_add_image_disk_to_tools_table.php
+++ b/database/migrations/2026_03_18_090000_add_image_disk_to_tools_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    public function up() : void
+    {
+        if (! Schema::hasTable('tools') || Schema::hasColumn('tools', 'image_disk')) {
+            return;
+        }
+
+        Schema::table('tools', function (Blueprint $table) {
+            $table->string('image_disk')->nullable();
+        });
+    }
+
+    public function down() : void
+    {
+        if (! Schema::hasTable('tools') || ! Schema::hasColumn('tools', 'image_disk')) {
+            return;
+        }
+
+        Schema::table('tools', function (Blueprint $table) {
+            $table->dropColumn('image_disk');
+        });
+    }
+};

--- a/resources/markdown/tools/cloudways-php.md
+++ b/resources/markdown/tools/cloudways-php.md
@@ -12,6 +12,7 @@ is_open_source: false
 categories:
   - "hosting"
   - "php"
+image_disk: null
 image_path: "resources/img/screenshots/cloudways.webp"
 review_post_slug: null
 published_at: 2026-03-11T09:00:00+00:00

--- a/resources/markdown/tools/cloudways-php.md
+++ b/resources/markdown/tools/cloudways-php.md
@@ -1,0 +1,19 @@
+---
+id: "01KP0KAD6R7WVVQ6T8S4TN3N7M"
+name: "Cloudways"
+slug: "cloudways-php"
+description: "Managed PHP hosting with scaling, caching, Cloudflare integration, and hands-off server upkeep."
+website_url: "https://www.cloudways.com/en/php-hosting.php"
+outbound_url: "https://www.cloudways.com/en/php-hosting.php?id=1242932"
+pricing_model: "paid"
+has_free_plan: false
+has_free_trial: true
+is_open_source: false
+categories:
+  - "hosting"
+  - "php"
+image_path: "resources/img/screenshots/cloudways.webp"
+review_post_slug: null
+published_at: 2026-03-11T09:00:00+00:00
+---
+Cloudways is the practical pick when you want managed PHP hosting without babysitting the whole server stack yourself.

--- a/resources/markdown/tools/digitalocean.md
+++ b/resources/markdown/tools/digitalocean.md
@@ -1,0 +1,19 @@
+---
+id: "01KP0KATPW7R3Y8XWQ0F7ZTTYY"
+name: "DigitalOcean"
+slug: "digitalocean"
+description: "Affordable VPS and managed infrastructure that still feels approachable when you want real control."
+website_url: "https://www.digitalocean.com/"
+outbound_url: "https://digitalocean.pxf.io/c/3801334/1377286/15890"
+pricing_model: "paid"
+has_free_plan: false
+has_free_trial: true
+is_open_source: false
+categories:
+  - "hosting"
+  - "cloud"
+image_path: "resources/img/screenshots/digitalocean.webp"
+review_post_slug: null
+published_at: 2026-03-10T09:00:00+00:00
+---
+DigitalOcean stays one of the easiest VPS platforms to recommend when you want predictable pricing and a cloud UI that does not fight you.

--- a/resources/markdown/tools/digitalocean.md
+++ b/resources/markdown/tools/digitalocean.md
@@ -12,6 +12,7 @@ is_open_source: false
 categories:
   - "hosting"
   - "cloud"
+image_disk: null
 image_path: "resources/img/screenshots/digitalocean.webp"
 review_post_slug: null
 published_at: 2026-03-10T09:00:00+00:00

--- a/resources/markdown/tools/fathom-analytics.md
+++ b/resources/markdown/tools/fathom-analytics.md
@@ -12,6 +12,7 @@ is_open_source: false
 categories:
   - "analytics"
   - "privacy"
+image_disk: null
 image_path: "resources/img/screenshots/fathom-analytics.webp"
 review_post_slug: null
 published_at: 2026-03-09T09:00:00+00:00

--- a/resources/markdown/tools/fathom-analytics.md
+++ b/resources/markdown/tools/fathom-analytics.md
@@ -1,0 +1,19 @@
+---
+id: "01KP0KB3BW6N3HE2P4RZCS1P0E"
+name: "Fathom Analytics"
+slug: "fathom-analytics"
+description: "Privacy-first website analytics with a small learning curve and none of the usual GA4 overhead."
+website_url: "https://usefathom.com/"
+outbound_url: "https://usefathom.com/ref/JTPOCN"
+pricing_model: "paid"
+has_free_plan: false
+has_free_trial: true
+is_open_source: false
+categories:
+  - "analytics"
+  - "privacy"
+image_path: "resources/img/screenshots/fathom-analytics.webp"
+review_post_slug: null
+published_at: 2026-03-09T09:00:00+00:00
+---
+Fathom is the clean analytics choice when you care about simple reporting, privacy, and a setup that takes minutes instead of a whole afternoon.

--- a/resources/markdown/tools/laravel-mcp.md
+++ b/resources/markdown/tools/laravel-mcp.md
@@ -1,0 +1,19 @@
+---
+id: "01KP0KBAB4DYAK8N0JTA5Y9D7J"
+name: "Laravel MCP"
+slug: "laravel-mcp"
+description: "Laravel’s MCP package helps SaaS apps expose governed AI-facing tools, resources, and prompts."
+website_url: "https://laravel.com/ai/mcp"
+outbound_url: "https://laravel.com/ai/mcp"
+pricing_model: "free"
+has_free_plan: true
+has_free_trial: false
+is_open_source: true
+categories:
+  - "ai"
+  - "laravel"
+image_path: null
+review_post_slug: "laravel-mcp-review"
+published_at: 2026-03-15T08:00:00+00:00
+---
+This one earns its place because it is both a real package and a useful signal about where app-facing AI integrations are heading.

--- a/resources/markdown/tools/laravel-mcp.md
+++ b/resources/markdown/tools/laravel-mcp.md
@@ -12,6 +12,7 @@ is_open_source: true
 categories:
   - "ai"
   - "laravel"
+image_disk: null
 image_path: null
 review_post_slug: "laravel-mcp-review"
 published_at: 2026-03-15T08:00:00+00:00

--- a/resources/markdown/tools/mailcoach.md
+++ b/resources/markdown/tools/mailcoach.md
@@ -1,0 +1,19 @@
+---
+id: "01KP0KBGDDBV0Z91T3H65C8W7Q"
+name: "Mailcoach"
+slug: "mailcoach"
+description: "Self-hosted email marketing and transactional sending built with Laravel teams in mind."
+website_url: "https://mailcoach.app/"
+outbound_url: "https://mailcoach.app/?via=benjamincrozat"
+pricing_model: "paid"
+has_free_plan: false
+has_free_trial: true
+is_open_source: false
+categories:
+  - "email"
+  - "laravel"
+image_path: "resources/img/screenshots/mailcoach.webp"
+review_post_slug: null
+published_at: 2026-03-08T09:00:00+00:00
+---
+Mailcoach is a strong fit if you want newsletter and campaign tooling that feels close to the Laravel ecosystem instead of bolted on from somewhere else.

--- a/resources/markdown/tools/mailcoach.md
+++ b/resources/markdown/tools/mailcoach.md
@@ -12,6 +12,7 @@ is_open_source: false
 categories:
   - "email"
   - "laravel"
+image_disk: null
 image_path: "resources/img/screenshots/mailcoach.webp"
 review_post_slug: null
 published_at: 2026-03-08T09:00:00+00:00

--- a/resources/markdown/tools/remodex.md
+++ b/resources/markdown/tools/remodex.md
@@ -12,6 +12,7 @@ is_open_source: true
 categories:
   - "ai"
   - "developer-tools"
+image_disk: null
 image_path: null
 review_post_slug: "remodex-review"
 published_at: 2026-03-16T09:00:00+00:00

--- a/resources/markdown/tools/remodex.md
+++ b/resources/markdown/tools/remodex.md
@@ -1,0 +1,19 @@
+---
+id: "01KP0KBPQ37T7D6G5E2M4Y71V6"
+name: "Remodex"
+slug: "remodex"
+description: "A local-first iPhone companion for Codex that keeps the real runtime on your Mac."
+website_url: "https://github.com/Emanuele-web04/remodex"
+outbound_url: "https://github.com/Emanuele-web04/remodex"
+pricing_model: "free"
+has_free_plan: true
+has_free_trial: false
+is_open_source: true
+categories:
+  - "ai"
+  - "developer-tools"
+image_path: null
+review_post_slug: "remodex-review"
+published_at: 2026-03-16T09:00:00+00:00
+---
+Remodex is the kind of companion app that feels more useful the moment you step away from your desk and still want to steer an active Codex run.

--- a/resources/markdown/tools/tinkerwell.md
+++ b/resources/markdown/tools/tinkerwell.md
@@ -1,0 +1,19 @@
+---
+id: "01KP0KBXT7BWDJ4PBT9PNGA1AF"
+name: "Tinkerwell"
+slug: "tinkerwell"
+description: "A desktop scratchpad for PHP and Laravel that makes debugging and quick experiments much faster."
+website_url: "https://tinkerwell.app/"
+outbound_url: "https://tinkerwell.app/?ref=benjamincrozat"
+pricing_model: "paid"
+has_free_plan: false
+has_free_trial: true
+is_open_source: false
+categories:
+  - "php"
+  - "debugging"
+image_path: "resources/img/screenshots/tinkerwell.webp"
+review_post_slug: null
+published_at: 2026-03-07T09:00:00+00:00
+---
+Tinkerwell is still one of the easiest ways to poke at Laravel code, prototype ideas, and inspect behavior without spinning up a whole UI for every little test.

--- a/resources/markdown/tools/tinkerwell.md
+++ b/resources/markdown/tools/tinkerwell.md
@@ -12,6 +12,7 @@ is_open_source: false
 categories:
   - "php"
   - "debugging"
+image_disk: null
 image_path: "resources/img/screenshots/tinkerwell.webp"
 review_post_slug: null
 published_at: 2026-03-07T09:00:00+00:00

--- a/resources/markdown/tools/tower.md
+++ b/resources/markdown/tools/tower.md
@@ -12,6 +12,7 @@ is_open_source: false
 categories:
   - "git"
   - "desktop"
+image_disk: null
 image_path: "resources/img/screenshots/tower.webp"
 review_post_slug: null
 published_at: 2026-03-06T09:00:00+00:00

--- a/resources/markdown/tools/tower.md
+++ b/resources/markdown/tools/tower.md
@@ -1,0 +1,19 @@
+---
+id: "01KP0KC497TSQ6S8N0WA7H9X8P"
+name: "Tower"
+slug: "tower"
+description: "A polished Git client for Mac and Windows that makes complex repo work feel much calmer."
+website_url: "https://www.git-tower.com/"
+outbound_url: "https://www.git-tower.com/?via=benjamincrozat"
+pricing_model: "paid"
+has_free_plan: false
+has_free_trial: true
+is_open_source: false
+categories:
+  - "git"
+  - "desktop"
+image_path: "resources/img/screenshots/tower.webp"
+review_post_slug: null
+published_at: 2026-03-06T09:00:00+00:00
+---
+Tower is the Git GUI I reach for when I want visual confidence around history, rebases, and multi-branch work instead of another round of terminal archaeology.

--- a/resources/markdown/tools/uptimia.md
+++ b/resources/markdown/tools/uptimia.md
@@ -1,0 +1,19 @@
+---
+id: "01KP0KCAKV6QSH4AM7DMB4QH95"
+name: "Uptimia"
+slug: "uptimia"
+description: "Website uptime, speed, and SSL monitoring from a broad network of checkpoints."
+website_url: "https://www.uptimia.com/"
+outbound_url: "https://www.uptimia.com/?via=benjamincrozat"
+pricing_model: "paid"
+has_free_plan: false
+has_free_trial: true
+is_open_source: false
+categories:
+  - "monitoring"
+  - "ops"
+image_path: "resources/img/screenshots/uptimia.webp"
+review_post_slug: null
+published_at: 2026-03-05T09:00:00+00:00
+---
+Uptimia is useful when you want one place for uptime, performance, and SSL checks without stitching together several smaller monitors.

--- a/resources/markdown/tools/uptimia.md
+++ b/resources/markdown/tools/uptimia.md
@@ -12,6 +12,7 @@ is_open_source: false
 categories:
   - "monitoring"
   - "ops"
+image_disk: null
 image_path: "resources/img/screenshots/uptimia.webp"
 review_post_slug: null
 published_at: 2026-03-05T09:00:00+00:00

--- a/resources/markdown/tools/wincher.md
+++ b/resources/markdown/tools/wincher.md
@@ -12,6 +12,7 @@ is_open_source: false
 categories:
   - "seo"
   - "marketing"
+image_disk: null
 image_path: "resources/img/screenshots/wincher.avif"
 review_post_slug: null
 published_at: 2026-03-04T09:00:00+00:00

--- a/resources/markdown/tools/wincher.md
+++ b/resources/markdown/tools/wincher.md
@@ -1,0 +1,19 @@
+---
+id: "01KP0KCGN6MDCT6KAW6P2AR6AN"
+name: "Wincher"
+slug: "wincher"
+description: "Rank tracking software with a friendlier UI than most SEO suites."
+website_url: "https://www.wincher.com/"
+outbound_url: "https://www.wincher.com/rank-tracker?via=benjamincrozat"
+pricing_model: "paid"
+has_free_plan: false
+has_free_trial: true
+is_open_source: false
+categories:
+  - "seo"
+  - "marketing"
+image_path: "resources/img/screenshots/wincher.avif"
+review_post_slug: null
+published_at: 2026-03-04T09:00:00+00:00
+---
+Wincher stays appealing because it focuses on the tracking job itself and does not force you into a giant all-in-one SEO dashboard just to watch rankings.

--- a/resources/views/components/tool-card.blade.php
+++ b/resources/views/components/tool-card.blade.php
@@ -1,6 +1,6 @@
 {{--
 Accepts: $tool, a published App\Models\Tool instance with optional review and image metadata.
-Keeps each tool recommendation card consistent across the catalog while exposing both outbound and review actions.
+Adapts each database-backed tool to the older horizontal recommendation card presentation used on the tools page.
 --}}
 
 @props([
@@ -8,80 +8,34 @@ Keeps each tool recommendation card consistent across the catalog while exposing
 ])
 
 @php
-    $reviewPost = $tool->reviewPost;
-    $canReadReview = $reviewPost?->isPublished();
+    $ctaColors = [
+        'cloudways-php' => 'bg-[#3641C2]!',
+        'digitalocean' => null,
+        'fathom-analytics' => 'bg-[#171B18]!',
+        'mailcoach' => 'bg-[#142C6E]!',
+        'tinkerwell' => 'bg-[#4470D4]!',
+        'tower' => 'bg-[#FDCB18]!',
+        'uptimia' => 'bg-[#009950]!',
+        'wincher' => 'bg-[#F09B4F]!',
+    ];
 
-    $badges = collect([
-        $tool->pricing_label,
-        $tool->has_free_plan ? 'Free plan' : null,
-        $tool->has_free_trial ? 'Free trial' : null,
-        $tool->is_open_source ? 'Open source' : null,
-    ])->filter()->values();
+    $ctaTextColors = [
+        'tower' => 'text-yellow-950!',
+    ];
+
+    $subheadline = filled($tool->content)
+        ? $tool->content
+        : $tool->description;
 @endphp
 
-<article class="overflow-hidden rounded-2xl bg-gray-100/75 ring-1 ring-black/5">
-    <div class="flex flex-col gap-6 p-5 md:p-6">
-        @if ($tool->image_url)
-            <div class="overflow-hidden rounded-xl bg-white/70">
-                <img
-                    loading="lazy"
-                    src="{{ $tool->image_url }}"
-                    alt="{{ $tool->name }}"
-                    class="aspect-[16/9] w-full object-cover object-top"
-                />
-            </div>
-        @endif
-
-        <div class="flex flex-wrap gap-2">
-            @foreach ($badges as $badge)
-                <span class="rounded-full bg-white px-3 py-1 text-xs font-medium tracking-wide text-gray-700 uppercase ring-1 ring-black/5">
-                    {{ $badge }}
-                </span>
-            @endforeach
-        </div>
-
-        <div>
-            <p class="text-2xl font-medium tracking-tight text-black">
-                {{ $tool->name }}
-            </p>
-
-            <p class="mt-2 leading-tight text-gray-700">
-                {{ $tool->description }}
-            </p>
-        </div>
-
-        @if (filled($tool->content))
-            <x-prose class="grow leading-normal sm:text-balance">
-                {!! \App\Markdown\MarkdownRenderer::parse($tool->content) !!}
-            </x-prose>
-        @endif
-
-        @if (filled($tool->categories))
-            <div class="flex flex-wrap gap-2 text-sm text-gray-600">
-                @foreach ($tool->categories as $category)
-                    <span>#{{ $category }}</span>
-                @endforeach
-            </div>
-        @endif
-
-        <div class="flex flex-wrap gap-3">
-            <x-btn
-                href="{{ route('merchants.show', $tool->slug) }}"
-                primary
-                target="_blank"
-                rel="sponsored noopener"
-            >
-                Visit tool
-            </x-btn>
-
-            @if ($canReadReview)
-                <x-btn
-                    href="{{ route('posts.show', $reviewPost) }}"
-                    wire:navigate
-                >
-                    Read review
-                </x-btn>
-            @endif
-        </div>
-    </div>
-</article>
+<x-tools.item
+    href="{{ route('merchants.show', $tool->slug) }}"
+    name="{{ $tool->name }}"
+    headline="{{ $tool->name }}"
+    :subheadline="$subheadline"
+    cta="Visit tool"
+    :cta-color="$ctaColors[$tool->slug] ?? null"
+    :cta-text-color="$ctaTextColors[$tool->slug] ?? null"
+    :src="$tool->image_url"
+    rel="sponsored noopener"
+/>

--- a/resources/views/components/tool-card.blade.php
+++ b/resources/views/components/tool-card.blade.php
@@ -8,34 +8,89 @@ Adapts each database-backed tool to the older horizontal recommendation card pre
 ])
 
 @php
-    $ctaColors = [
-        'cloudways-php' => 'bg-[#3641C2]!',
-        'digitalocean' => null,
-        'fathom-analytics' => 'bg-[#171B18]!',
-        'mailcoach' => 'bg-[#142C6E]!',
-        'tinkerwell' => 'bg-[#4470D4]!',
-        'tower' => 'bg-[#FDCB18]!',
-        'uptimia' => 'bg-[#009950]!',
-        'wincher' => 'bg-[#F09B4F]!',
+    $presets = [
+        'cloudways-php' => [
+            'headline' => 'Easily deploy PHP web apps',
+            'subheadline' => 'PHP 8, scalability, Cloudflare, caching, 24/7 support, and more with Cloudways.',
+            'cta' => 'Start free',
+            'cta_color' => 'bg-[#3641C2]!',
+        ],
+        'digitalocean' => [
+            'headline' => 'Host your web apps on a VPS',
+            'subheadline' => 'DigitalOcean provides affordable, scalable, and reliable VPS hosting.',
+            'cta' => 'Start with $200 free credit',
+        ],
+        'fathom-analytics' => [
+            'headline' => 'Know who visits your site',
+            'subheadline' => 'Fathom Analytics is a simple, privacy-focused web analytics. No cookies, ads, or tracking.',
+            'cta' => 'Start free + $10 off',
+            'cta_color' => 'bg-[#171B18]!',
+        ],
+        'mailcoach' => [
+            'headline' => 'Send emails to your users',
+            'subheadline' => 'Self-hosted email marketing built for Laravel developers, by Laravel developers.',
+            'cta' => 'Start free',
+            'cta_color' => 'bg-[#142C6E]!',
+        ],
+        'tinkerwell' => [
+            'headline' => 'Prototype and debug on the fly',
+            'subheadline' => 'Tinkerwell lets you code and debug your PHP, Laravel, Symfony, WordPress, etc., apps in an editor designed for fast feedback and quick iterations.',
+            'cta' => 'Get started',
+            'cta_color' => 'bg-[#4470D4]!',
+        ],
+        'tower' => [
+            'headline' => 'Unlock the power of Git',
+            'subheadline' => 'Tower is an easy-to-use and powerful Git client for Mac and Windows.',
+            'cta' => 'Start free',
+            'cta_color' => 'bg-[#FDCB18]!',
+            'cta_text_color' => 'text-yellow-950!',
+        ],
+        'uptimia' => [
+            'headline' => 'Get alerts when your site is down',
+            'subheadline' => 'Uptimia monitors your site’s uptime, speed, and SSL from 170+ global checkpoints.',
+            'cta' => 'Start free',
+            'cta_color' => 'bg-[#009950]!',
+        ],
+        'wincher' => [
+            'headline' => 'Rank higher on Google',
+            'subheadline' => 'Use Wincher to track and grow your business’s search visibility. **Use WELCOME30 for 30% off your first invoice.**',
+            'cta' => 'Start free',
+            'cta_color' => 'bg-[#F09B4F]!',
+        ],
+        'remodex' => [
+            'cta' => 'View on GitHub',
+        ],
+        'laravel-mcp' => [
+            'cta' => 'Read docs',
+        ],
     ];
 
-    $ctaTextColors = [
-        'tower' => 'text-yellow-950!',
-    ];
+    $preset = $presets[$tool->slug] ?? [];
 
-    $subheadline = filled($tool->content)
+    $headline = $preset['headline'] ?? $tool->name;
+
+    $subheadline = $preset['subheadline'] ?? (
+        filled($tool->content)
         ? $tool->content
-        : $tool->description;
+        : $tool->description
+    );
+
+    $cta = $preset['cta'] ?? match (true) {
+        str_contains($tool->outbound_url, 'github.com') => 'View on GitHub',
+        str_contains($tool->outbound_url, 'laravel.com') => 'Read docs',
+        $tool->has_free_plan || $tool->has_free_trial => 'Start free',
+        default => 'Visit website',
+    };
 @endphp
 
 <x-tools.item
     href="{{ route('merchants.show', $tool->slug) }}"
     name="{{ $tool->name }}"
-    headline="{{ $tool->name }}"
+    headline="{{ $headline }}"
     :subheadline="$subheadline"
-    cta="Visit tool"
-    :cta-color="$ctaColors[$tool->slug] ?? null"
-    :cta-text-color="$ctaTextColors[$tool->slug] ?? null"
+    :cta="$cta"
+    :cta-color="$preset['cta_color'] ?? null"
+    :cta-text-color="$preset['cta_text_color'] ?? null"
     :src="$tool->image_url"
     rel="sponsored noopener"
 />

--- a/resources/views/components/tool-card.blade.php
+++ b/resources/views/components/tool-card.blade.php
@@ -1,0 +1,86 @@
+{{--
+Presents a Markdown-managed tool card.
+--}}
+
+@props([
+    'tool',
+])
+
+@php
+    $reviewPost = $tool->reviewPost;
+    $canReadReview = $reviewPost?->isPublished();
+
+    $badges = collect([
+        $tool->pricing_label,
+        $tool->has_free_plan ? 'Free plan' : null,
+        $tool->has_free_trial ? 'Free trial' : null,
+        $tool->is_open_source ? 'Open source' : null,
+    ])->filter()->values();
+@endphp
+
+<article class="overflow-hidden rounded-2xl bg-gray-100/75 ring-1 ring-black/5">
+    <div class="flex flex-col gap-6 p-5 md:p-6">
+        @if ($tool->image_url)
+            <div class="overflow-hidden rounded-xl bg-white/70">
+                <img
+                    loading="lazy"
+                    src="{{ $tool->image_url }}"
+                    alt="{{ $tool->name }}"
+                    class="aspect-[16/9] w-full object-cover object-top"
+                />
+            </div>
+        @endif
+
+        <div class="flex flex-wrap gap-2">
+            @foreach ($badges as $badge)
+                <span class="rounded-full bg-white px-3 py-1 text-xs font-medium tracking-wide text-gray-700 uppercase ring-1 ring-black/5">
+                    {{ $badge }}
+                </span>
+            @endforeach
+        </div>
+
+        <div>
+            <p class="text-2xl font-medium tracking-tight text-black">
+                {{ $tool->name }}
+            </p>
+
+            <p class="mt-2 leading-tight text-gray-700">
+                {{ $tool->description }}
+            </p>
+        </div>
+
+        @if (filled($tool->content))
+            <x-prose class="grow leading-normal sm:text-balance">
+                {!! \App\Markdown\MarkdownRenderer::parse($tool->content) !!}
+            </x-prose>
+        @endif
+
+        @if (filled($tool->categories))
+            <div class="flex flex-wrap gap-2 text-sm text-gray-600">
+                @foreach ($tool->categories as $category)
+                    <span>#{{ $category }}</span>
+                @endforeach
+            </div>
+        @endif
+
+        <div class="flex flex-wrap gap-3">
+            <x-btn
+                href="{{ route('merchants.show', $tool->slug) }}"
+                primary
+                target="_blank"
+                rel="sponsored noopener"
+            >
+                Visit tool
+            </x-btn>
+
+            @if ($canReadReview)
+                <x-btn
+                    href="{{ route('posts.show', $reviewPost) }}"
+                    wire:navigate
+                >
+                    Read review
+                </x-btn>
+            @endif
+        </div>
+    </div>
+</article>

--- a/resources/views/components/tool-card.blade.php
+++ b/resources/views/components/tool-card.blade.php
@@ -1,5 +1,6 @@
 {{--
-Presents a Markdown-managed tool card.
+Accepts: $tool, a published App\Models\Tool instance with optional review and image metadata.
+Keeps each tool recommendation card consistent across the catalog while exposing both outbound and review actions.
 --}}
 
 @props([

--- a/resources/views/components/tools/item.blade.php
+++ b/resources/views/components/tools/item.blade.php
@@ -38,12 +38,14 @@ Presents the tools item component UI and accepts component props, Blade attribut
         </x-btn>
     </div>
 
-    <div class="relative flex-none w-[20%] sm:w-[33.33%] lg:flex-1">
-        <img
-            loading="lazy"
-            src="{{ $src }}"
-            alt="{{ $name }}"
-            class="object-cover absolute inset-0 w-full h-full ring-1 shadow-2xl ring-black/10 object-top-left"
-        />
-    </div>
+    @if (filled($src))
+        <div class="relative flex-none w-[20%] sm:w-[33.33%] lg:flex-1">
+            <img
+                loading="lazy"
+                src="{{ $src }}"
+                alt="{{ $name }}"
+                class="object-cover absolute inset-0 w-full h-full ring-1 shadow-2xl ring-black/10 object-top-left"
+            />
+        </div>
+    @endif
 </a>

--- a/resources/views/tools/index.blade.php
+++ b/resources/views/tools/index.blade.php
@@ -1,5 +1,5 @@
 {{--
-Displays the tools index view.
+Pairs the sponsored placement with the database-backed tool catalog so readers can browse the latest recommendations in one pass.
 --}}
 
 <x-app

--- a/resources/views/tools/index.blade.php
+++ b/resources/views/tools/index.blade.php
@@ -34,16 +34,17 @@ Displays the tools index view.
             Services and apps of all kinds to help you do your job more efficiently.
         </p>
 
-        <div class="grid gap-8 mt-8 md:grid-cols-2">
-            <x-tools.tinkerwell />
-            <x-tools.tower />
-            <x-tools.fathom-analytics />
-            <x-tools.cloudways />
-            <x-tools.mailcoach />
-            <x-tools.wincher />
-            <x-tools.uptimia />
-            <x-tools.digitalocean />
-        </div>
+        @if ($tools->isEmpty())
+            <p class="px-4 mt-8 text-center text-gray-600">
+                No tools are published yet.
+            </p>
+        @else
+            <div class="grid gap-8 mt-8 md:grid-cols-2">
+                @foreach ($tools as $tool)
+                    <x-tool-card :tool="$tool" />
+                @endforeach
+            </div>
+        @endif
     </x-section>
 
     <script type="application/ld+json">

--- a/tests/Feature/App/Console/Commands/SyncToolsCommandTest.php
+++ b/tests/Feature/App/Console/Commands/SyncToolsCommandTest.php
@@ -1,0 +1,151 @@
+<?php
+
+use App\Models\Post;
+use App\Models\Tool;
+use Illuminate\Support\Str;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Artisan;
+
+function syncToolsMarkdownPath() : string
+{
+    return (string) config('blog.markdown.tools_path');
+}
+
+beforeEach(function () {
+    $markdownPath = storage_path('framework/testing/tool-markdown-sync-' . Str::uuid());
+
+    File::deleteDirectory($markdownPath);
+    File::ensureDirectoryExists($markdownPath);
+
+    config()->set('blog.markdown.tools_path', $markdownPath);
+});
+
+afterEach(function () {
+    File::deleteDirectory(syncToolsMarkdownPath());
+});
+
+function syncToolsFrontMatter(array $attributes) : string
+{
+    $lines = [];
+
+    foreach ($attributes as $key => $value) {
+        if ('categories' === $key) {
+            $lines[] = 'categories:';
+
+            foreach ($value as $category) {
+                $lines[] = "  - {$category}";
+            }
+
+            continue;
+        }
+
+        if (is_bool($value)) {
+            $value = $value ? 'true' : 'false';
+        } elseif (null === $value) {
+            $value = 'null';
+        }
+
+        $lines[] = "{$key}: {$value}";
+    }
+
+    return "---\n" . implode("\n", $lines) . "\n---\n";
+}
+
+function writeSyncTool(string $basePath, string $slug, array $attributes, string $body = 'Tool body') : void
+{
+    File::put(
+        $basePath . "/{$slug}.md",
+        syncToolsFrontMatter($attributes) . $body
+    );
+}
+
+it('creates a tool from markdown and links its review post', function () {
+    $reviewPost = Post::factory()->create([
+        'slug' => 'remodex-review',
+        'published_at' => now()->subDay(),
+    ]);
+
+    writeSyncTool(syncToolsMarkdownPath(), 'remodex', [
+        'id' => '01KP0KBPQ37T7D6G5E2M4Y71V6',
+        'name' => '"Remodex"',
+        'slug' => 'remodex',
+        'description' => '"A local-first Codex companion for iPhone."',
+        'website_url' => '"https://github.com/Emanuele-web04/remodex"',
+        'outbound_url' => '"https://github.com/Emanuele-web04/remodex"',
+        'pricing_model' => '"free"',
+        'has_free_plan' => true,
+        'has_free_trial' => false,
+        'is_open_source' => true,
+        'categories' => ['ai', 'developer-tools'],
+        'image_path' => 'null',
+        'review_post_slug' => '"remodex-review"',
+        'published_at' => '"2026-03-17T09:00:00+00:00"',
+    ], "A short tool summary.\n");
+
+    expect(Artisan::call('app:sync-tools', ['--directory' => syncToolsMarkdownPath()]))
+        ->toBe(0);
+
+    expect(Artisan::output())
+        ->toContain('created=1');
+
+    $tool = Tool::query()->where('source_uuid', '01KP0KBPQ37T7D6G5E2M4Y71V6')->firstOrFail();
+
+    expect($tool->name)->toBe('Remodex')
+        ->and($tool->reviewPost?->is($reviewPost))->toBeTrue()
+        ->and($tool->categories)->toBe(['ai', 'developer-tools'])
+        ->and($tool->content)->toBe("A short tool summary.\n")
+        ->and($tool->source_path)->toBe('remodex.md');
+});
+
+it('fails when a review post slug does not exist', function () {
+    writeSyncTool(syncToolsMarkdownPath(), 'missing-review', [
+        'id' => '01KP0KD4M8YB7ATV9W5J8A4GQ5',
+        'name' => '"Missing Review Tool"',
+        'slug' => 'missing-review',
+        'description' => '"A tool with a broken review link."',
+        'website_url' => '"https://example.com/tool"',
+        'outbound_url' => '"https://example.com/tool"',
+        'pricing_model' => '"paid"',
+        'has_free_plan' => false,
+        'has_free_trial' => true,
+        'is_open_source' => false,
+        'categories' => ['testing'],
+        'image_path' => 'null',
+        'review_post_slug' => '"not-a-real-post"',
+        'published_at' => '"2026-03-17T09:00:00+00:00"',
+    ]);
+
+    expect(Artisan::call('app:sync-tools', ['--directory' => syncToolsMarkdownPath()]))
+        ->toBe(1);
+
+    expect(Artisan::output())
+        ->toContain('Unknown review post slug [not-a-real-post]');
+});
+
+it('deletes a tool when its markdown file is removed', function () {
+    writeSyncTool(syncToolsMarkdownPath(), 'tower', [
+        'id' => '01KP0KD8T8VA1QGQ9S7QF8N1H6',
+        'name' => '"Tower"',
+        'slug' => 'tower',
+        'description' => '"A Git client for desktop."',
+        'website_url' => '"https://www.git-tower.com/"',
+        'outbound_url' => '"https://www.git-tower.com/?via=benjamincrozat"',
+        'pricing_model' => '"paid"',
+        'has_free_plan' => false,
+        'has_free_trial' => true,
+        'is_open_source' => false,
+        'categories' => ['git'],
+        'image_path' => '"resources/img/screenshots/tower.webp"',
+        'review_post_slug' => 'null',
+        'published_at' => '"2026-03-17T09:00:00+00:00"',
+    ]);
+
+    Artisan::call('app:sync-tools', ['--directory' => syncToolsMarkdownPath()]);
+
+    File::delete(syncToolsMarkdownPath() . '/tower.md');
+
+    expect(Artisan::call('app:sync-tools', ['--directory' => syncToolsMarkdownPath()]))
+        ->toBe(0);
+
+    expect(Tool::query()->where('slug', 'tower')->exists())->toBeFalse();
+});

--- a/tests/Feature/App/Console/Commands/SyncToolsCommandTest.php
+++ b/tests/Feature/App/Console/Commands/SyncToolsCommandTest.php
@@ -3,8 +3,12 @@
 use App\Models\Post;
 use App\Models\Tool;
 use Illuminate\Support\Str;
+
+use function Pest\Laravel\artisan;
+
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Artisan;
+use App\Console\Commands\SyncToolsCommand;
 
 function syncToolsMarkdownPath() : string
 {
@@ -118,11 +122,9 @@ it('fails when a review post slug does not exist', function () {
         'published_at' => '"2026-03-17T09:00:00+00:00"',
     ]);
 
-    expect(Artisan::call('app:sync-tools', ['--directory' => syncToolsMarkdownPath()]))
-        ->toBe(1);
-
-    expect(Artisan::output())
-        ->toContain('Unknown review post slug [not-a-real-post]');
+    artisan(SyncToolsCommand::class, ['--directory' => syncToolsMarkdownPath()])
+        ->expectsOutputToContain('Unknown review post slug [not-a-real-post]')
+        ->assertFailed();
 });
 
 it('deletes a tool when its markdown file is removed', function () {
@@ -213,11 +215,9 @@ it('fails when the tool id is not a valid ulid', function () {
         'published_at' => '"2026-03-17T09:00:00+00:00"',
     ]);
 
-    expect(Artisan::call('app:sync-tools', ['--directory' => syncToolsMarkdownPath()]))
-        ->toBe(1);
-
-    expect(Artisan::output())
-        ->toContain('Front matter key [id] must be a valid ULID.');
+    artisan(SyncToolsCommand::class, ['--directory' => syncToolsMarkdownPath()])
+        ->expectsOutputToContain('Front matter key [id] must be a valid ULID.')
+        ->assertFailed();
 });
 
 it('fails when published_at is not ISO-8601', function () {
@@ -239,11 +239,9 @@ it('fails when published_at is not ISO-8601', function () {
         'published_at' => '"tomorrow"',
     ]);
 
-    expect(Artisan::call('app:sync-tools', ['--directory' => syncToolsMarkdownPath()]))
-        ->toBe(1);
-
-    expect(Artisan::output())
-        ->toContain('Front matter key [published_at] must be an ISO-8601 datetime or null.');
+    artisan(SyncToolsCommand::class, ['--directory' => syncToolsMarkdownPath()])
+        ->expectsOutputToContain('Front matter key [published_at] must be an ISO-8601 datetime or null.')
+        ->assertFailed();
 });
 
 it('fails when pricing_model is invalid', function () {
@@ -265,11 +263,9 @@ it('fails when pricing_model is invalid', function () {
         'published_at' => '"2026-03-17T09:00:00+00:00"',
     ]);
 
-    expect(Artisan::call('app:sync-tools', ['--directory' => syncToolsMarkdownPath()]))
-        ->toBe(1);
-
-    expect(Artisan::output())
-        ->toContain('Front matter key [pricing_model] must be one of');
+    artisan(SyncToolsCommand::class, ['--directory' => syncToolsMarkdownPath()])
+        ->expectsOutputToContain('Front matter key [pricing_model] must be one of')
+        ->assertFailed();
 });
 
 it('fails when a disk-backed image_path is missing image_disk', function () {
@@ -291,9 +287,7 @@ it('fails when a disk-backed image_path is missing image_disk', function () {
         'published_at' => '"2026-03-17T09:00:00+00:00"',
     ]);
 
-    expect(Artisan::call('app:sync-tools', ['--directory' => syncToolsMarkdownPath()]))
-        ->toBe(1);
-
-    expect(Artisan::output())
-        ->toContain('Front matter key [image_path] requires [image_disk]');
+    artisan(SyncToolsCommand::class, ['--directory' => syncToolsMarkdownPath()])
+        ->expectsOutputToContain('Front matter key [image_path] requires [image_disk]')
+        ->assertFailed();
 });

--- a/tests/Feature/App/Console/Commands/SyncToolsCommandTest.php
+++ b/tests/Feature/App/Console/Commands/SyncToolsCommandTest.php
@@ -78,7 +78,7 @@ it('creates a tool from markdown and links its review post', function () {
         'is_open_source' => true,
         'categories' => ['ai', 'developer-tools'],
         'image_disk' => '"public"',
-        'image_path' => 'null',
+        'image_path' => '"images/tools/remodex.png"',
         'review_post_slug' => '"remodex-review"',
         'published_at' => '"2026-03-17T09:00:00+00:00"',
     ], "A short tool summary.\n");
@@ -270,4 +270,30 @@ it('fails when pricing_model is invalid', function () {
 
     expect(Artisan::output())
         ->toContain('Front matter key [pricing_model] must be one of');
+});
+
+it('fails when a disk-backed image_path is missing image_disk', function () {
+    writeSyncTool(syncToolsMarkdownPath(), 'bad-image', [
+        'id' => '01KP0KDBER66R3C81GZVWXW3B7',
+        'name' => '"Bad Image"',
+        'slug' => 'bad-image',
+        'description' => '"A tool with incomplete image metadata."',
+        'website_url' => '"https://example.com/tool"',
+        'outbound_url' => '"https://example.com/tool"',
+        'pricing_model' => '"free"',
+        'has_free_plan' => true,
+        'has_free_trial' => false,
+        'is_open_source' => true,
+        'categories' => ['testing'],
+        'image_disk' => 'null',
+        'image_path' => '"images/tools/foo.jpg"',
+        'review_post_slug' => 'null',
+        'published_at' => '"2026-03-17T09:00:00+00:00"',
+    ]);
+
+    expect(Artisan::call('app:sync-tools', ['--directory' => syncToolsMarkdownPath()]))
+        ->toBe(1);
+
+    expect(Artisan::output())
+        ->toContain('Front matter key [image_path] requires [image_disk]');
 });

--- a/tests/Feature/App/Console/Commands/SyncToolsCommandTest.php
+++ b/tests/Feature/App/Console/Commands/SyncToolsCommandTest.php
@@ -77,6 +77,7 @@ it('creates a tool from markdown and links its review post', function () {
         'has_free_trial' => false,
         'is_open_source' => true,
         'categories' => ['ai', 'developer-tools'],
+        'image_disk' => '"public"',
         'image_path' => 'null',
         'review_post_slug' => '"remodex-review"',
         'published_at' => '"2026-03-17T09:00:00+00:00"',
@@ -93,6 +94,7 @@ it('creates a tool from markdown and links its review post', function () {
     expect($tool->name)->toBe('Remodex')
         ->and($tool->reviewPost?->is($reviewPost))->toBeTrue()
         ->and($tool->categories)->toBe(['ai', 'developer-tools'])
+        ->and($tool->image_disk)->toBe('public')
         ->and($tool->content)->toBe("A short tool summary.\n")
         ->and($tool->source_path)->toBe('remodex.md');
 });
@@ -110,6 +112,7 @@ it('fails when a review post slug does not exist', function () {
         'has_free_trial' => true,
         'is_open_source' => false,
         'categories' => ['testing'],
+        'image_disk' => 'null',
         'image_path' => 'null',
         'review_post_slug' => '"not-a-real-post"',
         'published_at' => '"2026-03-17T09:00:00+00:00"',
@@ -135,6 +138,7 @@ it('deletes a tool when its markdown file is removed', function () {
         'has_free_trial' => true,
         'is_open_source' => false,
         'categories' => ['git'],
+        'image_disk' => 'null',
         'image_path' => '"resources/img/screenshots/tower.webp"',
         'review_post_slug' => 'null',
         'published_at' => '"2026-03-17T09:00:00+00:00"',
@@ -148,4 +152,122 @@ it('deletes a tool when its markdown file is removed', function () {
         ->toBe(0);
 
     expect(Tool::query()->where('slug', 'tower')->exists())->toBeFalse();
+});
+
+it('reassigns a review post cleanly when a replacement tool takes over', function () {
+    $reviewPost = Post::factory()->create([
+        'slug' => 'laravel-mcp-review',
+        'published_at' => now()->subDay(),
+    ]);
+
+    Tool::factory()->create([
+        'source_uuid' => '01KP0KD9D8ZVZ9CV08D2YCV8ZZ',
+        'slug' => 'old-laravel-mcp',
+        'review_post_id' => $reviewPost->getKey(),
+    ]);
+
+    writeSyncTool(syncToolsMarkdownPath(), 'laravel-mcp', [
+        'id' => '01KP0KDABYBCQW3MZB8Z0E3SKA',
+        'name' => '"Laravel MCP"',
+        'slug' => 'laravel-mcp',
+        'description' => '"An MCP server for Laravel projects."',
+        'website_url' => '"https://github.com/benjamincrozat/laravel-mcp"',
+        'outbound_url' => '"https://github.com/benjamincrozat/laravel-mcp"',
+        'pricing_model' => '"free"',
+        'has_free_plan' => true,
+        'has_free_trial' => false,
+        'is_open_source' => true,
+        'categories' => ['laravel', 'ai'],
+        'image_disk' => 'null',
+        'image_path' => 'null',
+        'review_post_slug' => '"laravel-mcp-review"',
+        'published_at' => '"2026-03-17T09:00:00+00:00"',
+    ]);
+
+    expect(Artisan::call('app:sync-tools', ['--directory' => syncToolsMarkdownPath()]))
+        ->toBe(0);
+
+    expect(Tool::query()->where('slug', 'old-laravel-mcp')->exists())->toBeFalse();
+
+    $tool = Tool::query()->where('slug', 'laravel-mcp')->firstOrFail();
+
+    expect($tool->reviewPost?->is($reviewPost))->toBeTrue();
+});
+
+it('fails when the tool id is not a valid ulid', function () {
+    writeSyncTool(syncToolsMarkdownPath(), 'bad-id', [
+        'id' => '"not-a-ulid"',
+        'name' => '"Bad ID"',
+        'slug' => 'bad-id',
+        'description' => '"A tool with an invalid source id."',
+        'website_url' => '"https://example.com/tool"',
+        'outbound_url' => '"https://example.com/tool"',
+        'pricing_model' => '"free"',
+        'has_free_plan' => true,
+        'has_free_trial' => false,
+        'is_open_source' => true,
+        'categories' => ['testing'],
+        'image_disk' => 'null',
+        'image_path' => 'null',
+        'review_post_slug' => 'null',
+        'published_at' => '"2026-03-17T09:00:00+00:00"',
+    ]);
+
+    expect(Artisan::call('app:sync-tools', ['--directory' => syncToolsMarkdownPath()]))
+        ->toBe(1);
+
+    expect(Artisan::output())
+        ->toContain('Front matter key [id] must be a valid ULID.');
+});
+
+it('fails when published_at is not ISO-8601', function () {
+    writeSyncTool(syncToolsMarkdownPath(), 'bad-published-at', [
+        'id' => '01KP0KDAMZ0AZ3CP6GFFVZXFJ6',
+        'name' => '"Bad Published At"',
+        'slug' => 'bad-published-at',
+        'description' => '"A tool with a non-deterministic publish date."',
+        'website_url' => '"https://example.com/tool"',
+        'outbound_url' => '"https://example.com/tool"',
+        'pricing_model' => '"free"',
+        'has_free_plan' => true,
+        'has_free_trial' => false,
+        'is_open_source' => true,
+        'categories' => ['testing'],
+        'image_disk' => 'null',
+        'image_path' => 'null',
+        'review_post_slug' => 'null',
+        'published_at' => '"tomorrow"',
+    ]);
+
+    expect(Artisan::call('app:sync-tools', ['--directory' => syncToolsMarkdownPath()]))
+        ->toBe(1);
+
+    expect(Artisan::output())
+        ->toContain('Front matter key [published_at] must be an ISO-8601 datetime or null.');
+});
+
+it('fails when pricing_model is invalid', function () {
+    writeSyncTool(syncToolsMarkdownPath(), 'bad-pricing', [
+        'id' => '01KP0KDB5XNZSAAWQ8M5Q7B419',
+        'name' => '"Bad Pricing"',
+        'slug' => 'bad-pricing',
+        'description' => '"A tool with an invalid pricing model."',
+        'website_url' => '"https://example.com/tool"',
+        'outbound_url' => '"https://example.com/tool"',
+        'pricing_model' => '"enterprise"',
+        'has_free_plan' => false,
+        'has_free_trial' => false,
+        'is_open_source' => false,
+        'categories' => ['testing'],
+        'image_disk' => 'null',
+        'image_path' => 'null',
+        'review_post_slug' => 'null',
+        'published_at' => '"2026-03-17T09:00:00+00:00"',
+    ]);
+
+    expect(Artisan::call('app:sync-tools', ['--directory' => syncToolsMarkdownPath()]))
+        ->toBe(1);
+
+    expect(Artisan::output())
+        ->toContain('Front matter key [pricing_model] must be one of');
 });

--- a/tests/Feature/App/Http/Controllers/Merchants/ShowMerchantControllerTest.php
+++ b/tests/Feature/App/Http/Controllers/Merchants/ShowMerchantControllerTest.php
@@ -1,6 +1,19 @@
 <?php
 
+use App\Models\Tool;
+
 use function Pest\Laravel\get;
+
+it('redirects tool slugs from the database with the same query parameters', function () {
+    Tool::factory()->create([
+        'slug' => 'remodex',
+        'outbound_url' => 'https://github.com/Emanuele-web04/remodex',
+        'published_at' => now()->subMinute(),
+    ]);
+
+    get(route('merchants.show', ['remodex', 'foo' => 'bar']))
+        ->assertRedirectContains('https://github.com/Emanuele-web04/remodex?foo=bar');
+});
 
 it('redirects to the merchant with the same query parameters', function () {
     get(route('merchants.show', ['ploi', 'foo' => 'bar']))

--- a/tests/Feature/App/Http/Controllers/Tools/ListToolsControllerTest.php
+++ b/tests/Feature/App/Http/Controllers/Tools/ListToolsControllerTest.php
@@ -1,15 +1,32 @@
 <?php
 
+use App\Models\Tool;
+
 use function Pest\Laravel\get;
 
-it('shows the tools index with breadcrumbs', function () {
+it('shows the tools index with breadcrumbs and published tools', function () {
+    $publishedTool = Tool::factory()->create([
+        'name' => 'Remodex',
+        'slug' => 'remodex',
+        'published_at' => now()->subHour(),
+    ]);
+
+    Tool::factory()->create([
+        'name' => 'Draft Tool',
+        'slug' => 'draft-tool',
+        'published_at' => now()->addHour(),
+    ]);
+
     get(route('tools.index'))
         ->assertOk()
         ->assertViewIs('tools.index')
+        ->assertSee('Remodex')
+        ->assertDontSee('Draft Tool')
         ->assertViewHas('breadcrumbs', [
             ['label' => 'Home', 'url' => route('home')],
             ['label' => 'Tools'],
         ])
+        ->assertViewHas('tools', fn ($tools) => $tools->contains($publishedTool))
         ->assertViewHas('breadcrumbSchema', [
             '@context' => 'https://schema.org',
             '@type' => 'BreadcrumbList',

--- a/tests/Feature/App/Models/ToolTest.php
+++ b/tests/Feature/App/Models/ToolTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Models\Tool;
+use Illuminate\Support\Facades\Vite;
 use Illuminate\Support\Facades\Storage;
 
 it('returns null for image_url when the tool has no image', function () {
@@ -21,4 +22,22 @@ it('returns the correct image_url when the tool image uses a configured disk', f
     ]);
 
     expect($tool->image_url)->toMatch('/\/images\/tools\/foo\.jpg$/');
+});
+
+it('returns the correct image_url for resource-backed catalog images', function () {
+    $tool = Tool::factory()->create([
+        'image_disk' => null,
+        'image_path' => 'resources/img/screenshots/tool.webp',
+    ]);
+
+    expect($tool->image_url)->toBe(Vite::asset('resources/img/screenshots/tool.webp'));
+});
+
+it('returns the image_url as-is for absolute URLs', function () {
+    $tool = Tool::factory()->create([
+        'image_disk' => null,
+        'image_path' => 'https://cdn.example.com/tool.png',
+    ]);
+
+    expect($tool->image_url)->toBe('https://cdn.example.com/tool.png');
 });

--- a/tests/Feature/App/Models/ToolTest.php
+++ b/tests/Feature/App/Models/ToolTest.php
@@ -1,0 +1,24 @@
+<?php
+
+use App\Models\Tool;
+use Illuminate\Support\Facades\Storage;
+
+it('returns null for image_url when the tool has no image', function () {
+    $tool = Tool::factory()->create([
+        'image_disk' => null,
+        'image_path' => null,
+    ]);
+
+    expect($tool->image_url)->toBeNull();
+});
+
+it('returns the correct image_url when the tool image uses a configured disk', function () {
+    Storage::fake('public');
+
+    $tool = Tool::factory()->create([
+        'image_disk' => 'public',
+        'image_path' => 'images/tools/foo.jpg',
+    ]);
+
+    expect($tool->image_url)->toMatch('/\/images\/tools\/foo\.jpg$/');
+});


### PR DESCRIPTION
## Summary
- add a markdown-backed  model and sync command for developer tool metadata
- render the  catalog from the database and resolve  from tools first
- cover sync validation, listing, and redirect behavior with feature tests

## Verification
- php artisan app:sync-tools
- php vendor/bin/pint --parallel
- php vendor/bin/phpstan analyse
- php vendor/bin/pest tests/Feature/App/Console/Commands/SyncToolsCommandTest.php tests/Feature/App/Http/Controllers/Tools/ListToolsControllerTest.php tests/Feature/App/Http/Controllers/Merchants/ShowMerchantControllerTest.php

## Notes
- Full parallel Pest still has unrelated existing repo failures around the test database setup in this environment.