### PR TITLE
Add GPT-5.4 mini and nano guides

### DIFF
--- a/resources/markdown/posts/gpt-54-mini-api.md
+++ b/resources/markdown/posts/gpt-54-mini-api.md
@@ -19,11 +19,11 @@ sponsored_at: null
 ---
 ## What this GPT-5.4 mini guide covers
 
-OpenAI released GPT-5.4 mini on March 17, 2026 in its [launch post](https://openai.com/index/introducing-gpt-5-4-mini-and-nano/). The current [GPT-5.4 mini model page](https://developers.openai.com/api/docs/models/gpt-5.4-mini) describes it as OpenAI's strongest mini model yet for coding, computer use, and subagents.
+OpenAI introduced the GPT-5.4 family on March 5, 2026 in its [GPT-5.4 launch post](https://openai.com/index/introducing-gpt-5-4/). The current [GPT-5.4 mini model page](https://developers.openai.com/api/docs/models/gpt-5.4-mini) describes mini as OpenAI's strongest mini model yet for coding, computer use, and subagents.
 
-That makes GPT-5.4 mini the practical middle ground in the GPT-5.4 family. It is built for high-volume workloads, it brings the strengths of GPT-5.4 to a smaller model, and it improves noticeably over GPT-5 mini across coding, reasoning, multimodal understanding, and tool use. OpenAI also says it runs more than 2x faster than GPT-5 mini.
+That makes GPT-5.4 mini the practical middle ground in the GPT-5.4 family. The model page says it brings the strengths of GPT-5.4 to a faster, more efficient model designed for high-volume workloads.
 
-If you are starting fresh and want the flagship option first, read my [GPT-5.4 API guide](/gpt-54-api). If you only care about the cheapest branch, compare this with [GPT-5.4 nano](/gpt-5-nano-api).
+If you are starting fresh and want the flagship option first, read my [GPT-5.4 API guide](/gpt-54-api). If you only care about the cheapest branch, compare this with [GPT-5.4 nano](/gpt-54-nano-api).
 
 By the end, you will have:
 
@@ -77,7 +77,7 @@ curl -s https://api.openai.com/v1/responses \
   }'
 ```
 
-That gives you a quick way to verify the API key, endpoint, and model selection are all working.
+If your key and billing are set up correctly, that gives you a quick way to verify the endpoint and model selection are working.
 
 The model page also lists the parts that matter for real apps:
 
@@ -160,7 +160,7 @@ curl -s https://api.openai.com/v1/responses \
   }'
 ```
 
-That request should give you JSON shaped like this:
+If everything is wired correctly, you should get JSON shaped like this:
 
 ```json
 {
@@ -184,9 +184,9 @@ If you want to move this pattern into PHP next, my guide on [using OpenAI's API 
 
 GPT-5.4 mini sits in a sweet spot.
 
-The launch post says it is a significant upgrade over GPT-5 mini, and the model page backs that up with a clearer value proposition: a faster, more efficient model for high-volume workloads. The pricing page puts it at [\$0.75 input and \$4.50 output per 1M tokens](https://openai.com/api/pricing/), while the same comparison area shows GPT-5.4 at [\$2.50 input and \$15 output per 1M tokens](https://openai.com/api/pricing/). That makes GPT-5.4 mini much cheaper than the full model while still staying in the newer GPT-5.4 family.
+The model page backs up a clear value proposition: a faster, more efficient model for high-volume workloads. The pricing page puts it at [\$0.75 input and \$4.50 output per 1M tokens](https://openai.com/api/pricing/), while the same comparison area shows GPT-5.4 at [\$2.50 input and \$15 output per 1M tokens](https://openai.com/api/pricing/). That makes GPT-5.4 mini much cheaper than the full model while still staying in the newer GPT-5.4 family.
 
-So if your task is precise and repeatable, mini often makes more sense than the flagship model. If the work is even narrower and cost is the main constraint, [GPT-5.4 nano](/gpt-5-nano-api) is the next model I would compare.
+So if your task is precise and repeatable, mini often makes more sense than the flagship model. If the work is even narrower and cost is the main constraint, [GPT-5.4 nano](/gpt-54-nano-api) is the next model I would compare.
 
 ## How I would use GPT-5.4 mini
 
@@ -211,11 +211,11 @@ This model shines when you tell it exactly what to classify, extract, or decide.
 
 ### 3. Skipping the cheaper or larger sibling when the fit is obvious
 
-If you only need very fast, very cheap classification, [GPT-5.4 nano](/gpt-5-nano-api) may be enough. If the task needs more breadth or judgment, [GPT-5.4](/gpt-54-api) is the better upgrade path.
+If you only need very fast, very cheap classification, [GPT-5.4 nano](/gpt-54-nano-api) may be enough. If the task needs more breadth or judgment, [GPT-5.4](/gpt-54-api) is the better upgrade path.
 
 If GPT-5.4 mini looks close to what you need, these are the next reads I would keep open:
 
 - [See when the full GPT-5.4 model is still worth the extra cost](/gpt-54-api)
-- [Compare GPT-5.4 mini with the cheaper GPT-5.4 nano](/gpt-5-nano-api)
+- [Compare GPT-5.4 mini with the cheaper GPT-5.4 nano](/gpt-54-nano-api)
 - [Move this same structured-output pattern into PHP](/openai-php-client)
 - [Build a better mental model for what GPT-style models are actually doing](/how-llms-work)

--- a/resources/markdown/posts/gpt-54-mini-api.md
+++ b/resources/markdown/posts/gpt-54-mini-api.md
@@ -1,0 +1,221 @@
+---
+id: "01KXQ2Z5Y7R8J6M1N4P9V3C8HD"
+title: "GPT-5.4 mini API quick start with a real workflow"
+slug: "gpt-54-mini-api"
+author: "benjamincrozat"
+description: "Learn GPT-5.4 mini step by step by sending your first API request and building a structured workflow for coding-friendly, high-volume tasks."
+categories:
+  - "ai"
+  - "gpt"
+published_at: 2026-03-18T00:00:00Z
+modified_at: 2026-03-18T00:00:00Z
+serp_title: null
+serp_description: null
+canonical_url: null
+is_commercial: false
+image_disk: "cloudflare-images"
+image_path: "images/posts/generated/gpt-54-mini-api.png"
+sponsored_at: null
+---
+## What this GPT-5.4 mini guide covers
+
+OpenAI released GPT-5.4 mini on March 17, 2026 in its [launch post](https://openai.com/index/introducing-gpt-5-4-mini-and-nano/). The current [GPT-5.4 mini model page](https://developers.openai.com/api/docs/models/gpt-5.4-mini) describes it as OpenAI's strongest mini model yet for coding, computer use, and subagents.
+
+That makes GPT-5.4 mini the practical middle ground in the GPT-5.4 family. It is built for high-volume workloads, it brings the strengths of GPT-5.4 to a smaller model, and it improves noticeably over GPT-5 mini across coding, reasoning, multimodal understanding, and tool use. OpenAI also says it runs more than 2x faster than GPT-5 mini.
+
+If you are starting fresh and want the flagship option first, read my [GPT-5.4 API guide](/gpt-54-api). If you only care about the cheapest branch, compare this with [GPT-5.4 nano](/gpt-5-nano-api).
+
+By the end, you will have:
+
+- a first successful GPT-5.4 mini Responses API call
+- a structured support-triage workflow that returns strict JSON
+
+## Get your API key ready
+
+You need an OpenAI account, a funded API project, and an API key from the [API keys page](https://platform.openai.com/api-keys). Keys are shown once, so save yours right away.
+
+Then export it in your terminal.
+
+macOS and Linux:
+
+```bash
+export OPENAI_API_KEY="sk-..."
+```
+
+Windows Command Prompt:
+
+```cmd
+setx OPENAI_API_KEY "sk-..."
+```
+
+If you use `setx`, open a new terminal before testing the key.
+
+## Send your first GPT-5.4 mini request
+
+GPT-5.4 mini uses the same [Responses API](https://platform.openai.com/docs/api-reference/responses/create) shape as the rest of the GPT-5.4 family, so the first request stays simple.
+
+This exact request is a good first check:
+
+```bash
+curl -s https://api.openai.com/v1/responses \
+  -H "Authorization: Bearer $OPENAI_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "gpt-5.4-mini-2026-03-17",
+    "input": [
+      {
+        "role": "user",
+        "content": [
+          { "type": "input_text", "text": "Say hello in one short sentence." }
+        ]
+      }
+    ],
+    "text": {
+      "verbosity": "low"
+    },
+    "max_output_tokens": 80
+  }'
+```
+
+That gives you a quick way to verify the API key, endpoint, and model selection are all working.
+
+The model page also lists the parts that matter for real apps:
+
+- 400,000 context window
+- 128,000 max output tokens
+- text and image input
+- structured outputs
+- function calling
+- web search, file search, image generation, code interpreter, hosted shell, apply patch, skills, computer use, MCP, and tool search
+
+## Build something useful: support triage
+
+Now let us turn the first successful call into something you could actually ship.
+
+Imagine your app receives this support message:
+
+```text
+Hi, I was billed twice for my Pro plan today. Please refund the extra charge.
+```
+
+You want GPT-5.4 mini to do four things in one pass:
+
+1. classify the issue
+2. set a priority
+3. decide whether a human should step in
+4. draft a safe reply
+
+That is a good fit for this model because the output is bounded, the prompt is precise, and the result is easy to validate.
+
+## Return strict JSON with a schema
+
+```bash
+curl -s https://api.openai.com/v1/responses \
+  -H "Authorization: Bearer $OPENAI_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "gpt-5.4-mini-2026-03-17",
+    "instructions": "You triage support messages for a SaaS app. Be cautious. Do not promise actions the billing team has not confirmed. Keep reply_draft to 2 short sentences.",
+    "input": [
+      {
+        "role": "user",
+        "content": [
+          {
+            "type": "input_text",
+            "text": "Hi, I was billed twice for my Pro plan today. Please refund the extra charge."
+          }
+        ]
+      }
+    ],
+    "text": {
+      "verbosity": "low",
+      "format": {
+        "type": "json_schema",
+        "name": "support_triage",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "category": {
+              "type": "string",
+              "enum": ["billing", "bug", "account", "feature_request", "other"]
+            },
+            "priority": {
+              "type": "string",
+              "enum": ["low", "medium", "high"]
+            },
+            "needs_human": {
+              "type": "boolean"
+            },
+            "reply_draft": {
+              "type": "string"
+            }
+          },
+          "required": ["category", "priority", "needs_human", "reply_draft"],
+          "additionalProperties": false
+        },
+        "strict": true
+      }
+    },
+    "max_output_tokens": 220
+  }'
+```
+
+That request should give you JSON shaped like this:
+
+```json
+{
+  "category": "billing",
+  "priority": "high",
+  "needs_human": true,
+  "reply_draft": "Sorry about the duplicate charge. I have flagged this to our billing team to review the transaction and follow up with you."
+}
+```
+
+That is immediately useful in an app:
+
+- `category` can route the ticket
+- `priority` can change queue order
+- `needs_human` can trigger escalation
+- `reply_draft` can prefill the first response
+
+If you want to move this pattern into PHP next, my guide on [using OpenAI's API in PHP with openai-php/client](/openai-php-client) picks up right there.
+
+## What changes with GPT-5.4 mini
+
+GPT-5.4 mini sits in a sweet spot.
+
+The launch post says it is a significant upgrade over GPT-5 mini, and the model page backs that up with a clearer value proposition: a faster, more efficient model for high-volume workloads. The pricing page puts it at [\$0.75 input and \$4.50 output per 1M tokens](https://openai.com/api/pricing/), while the same comparison area shows GPT-5.4 at [\$2.50 input and \$15 output per 1M tokens](https://openai.com/api/pricing/). That makes GPT-5.4 mini much cheaper than the full model while still staying in the newer GPT-5.4 family.
+
+So if your task is precise and repeatable, mini often makes more sense than the flagship model. If the work is even narrower and cost is the main constraint, [GPT-5.4 nano](/gpt-5-nano-api) is the next model I would compare.
+
+## How I would use GPT-5.4 mini
+
+I would reach for GPT-5.4 mini when:
+
+- the prompt is clear
+- the output shape is predictable
+- the task needs to be fast and affordable
+- the job is a coding assistant subtask, a computer-use step, or a structured classification workflow
+
+I would not use it as a blanket default for messy reasoning. If the task is ambiguous, long, or coordination-heavy, full [GPT-5.4](/gpt-54-api) still has the advantage.
+
+## Common mistakes with GPT-5.4 mini
+
+### 1. Treating it like the flagship by default
+
+Mini is excellent when the job is bounded. It is not the right starting point for every hard problem.
+
+### 2. Using vague prompts
+
+This model shines when you tell it exactly what to classify, extract, or decide.
+
+### 3. Skipping the cheaper or larger sibling when the fit is obvious
+
+If you only need very fast, very cheap classification, [GPT-5.4 nano](/gpt-5-nano-api) may be enough. If the task needs more breadth or judgment, [GPT-5.4](/gpt-54-api) is the better upgrade path.
+
+If GPT-5.4 mini looks close to what you need, these are the next reads I would keep open:
+
+- [See when the full GPT-5.4 model is still worth the extra cost](/gpt-54-api)
+- [Compare GPT-5.4 mini with the cheaper GPT-5.4 nano](/gpt-5-nano-api)
+- [Move this same structured-output pattern into PHP](/openai-php-client)
+- [Build a better mental model for what GPT-style models are actually doing](/how-llms-work)

--- a/resources/markdown/posts/gpt-54-nano-api.md
+++ b/resources/markdown/posts/gpt-54-nano-api.md
@@ -19,9 +19,9 @@ sponsored_at: null
 ---
 ## What this GPT-5.4 nano guide covers
 
-OpenAI released GPT-5.4 nano on March 17, 2026 in its [launch post](https://openai.com/index/introducing-gpt-5-4-mini-and-nano/). The current [GPT-5.4 nano model page](https://developers.openai.com/api/docs/models/gpt-5.4-nano) places it in the new GPT-5.4 family, and the current [pricing page](https://openai.com/api/pricing/) puts it at the low end of that lineup.
+OpenAI introduced the GPT-5.4 family on March 5, 2026 in its [GPT-5.4 launch post](https://openai.com/index/introducing-gpt-5-4/). The current [GPT-5.4 nano model page](https://developers.openai.com/api/docs/models/gpt-5.4-nano) places nano in that family, and the current [pricing page](https://openai.com/api/pricing/) puts it at the low end of that lineup.
 
-That makes GPT-5.4 nano the model I would reach for when the job is small, repetitive, and high-volume: classification, extraction, ranking, and lightweight routing to sub-agents. OpenAI also says it is a significant upgrade over GPT-5 nano.
+That makes GPT-5.4 nano the model I would reach for when the job is small, repetitive, and high-volume: classification, extraction, ranking, and lightweight routing to sub-agents.
 
 This guide uses the pinned snapshot `gpt-5.4-nano-2026-03-17`.
 
@@ -77,7 +77,7 @@ curl -s https://api.openai.com/v1/responses \
   }'
 ```
 
-That exact request completed successfully for me and returned `Hello!`.
+If your key and billing are set up correctly, you should get a short greeting back.
 
 ## Build something useful: route work to sub-agents
 
@@ -174,16 +174,6 @@ OpenAI's pricing page puts it at the low end of the GPT-5.4 family, which is why
 
 That also makes it a natural step up from the older [GPT-5 nano guide](/gpt-5-nano-api) when you want the newer GPT-5.4 family without jumping all the way to full GPT-5.4.
 
-## How I would choose reasoning effort on GPT-5.4 nano
-
-For nano, I would start with:
-
-- `minimal` for almost everything
-- `low` when the task needs a little more judgment
-- `medium` only when the prompt is still small but the answer quality is not quite there yet
-
-The key is to keep the task compact. Nano shines when the job is precise, not when it needs a long chain of reasoning.
-
 ## When GPT-5.4 nano is the right model
 
 Pick GPT-5.4 nano when you care about:
@@ -214,5 +204,5 @@ If GPT-5.4 nano looks close to what you need, these are the next reads I would k
 
 - [See the full GPT-5.4 API quick start for the flagship family](/gpt-54-api)
 - [Compare it with the older GPT-5 nano quick start](/gpt-5-nano-api)
-- [See the cheaper GPT-5 mini workflow for broader low-cost tasks](/gpt-5-mini-api)
+- [Step up to GPT-5.4 mini when you want a broader low-cost model](/gpt-54-mini-api)
 - [Move this same structured-output pattern into PHP](/openai-php-client)

--- a/resources/markdown/posts/gpt-54-nano-api.md
+++ b/resources/markdown/posts/gpt-54-nano-api.md
@@ -1,0 +1,218 @@
+---
+id: "01KQ9Z4JH8V3N6Q2M5T7R1P4C8"
+title: "GPT-5.4 nano API quick start with a real workflow"
+slug: "gpt-54-nano-api"
+author: "benjamincrozat"
+description: "Learn GPT-5.4 nano step by step by sending your first API request and building a fast routing workflow for high-volume tasks."
+categories:
+  - "ai"
+  - "gpt"
+published_at: 2026-03-18T00:00:00Z
+modified_at: 2026-03-18T00:00:00Z
+serp_title: null
+serp_description: null
+canonical_url: null
+is_commercial: false
+image_disk: "cloudflare-images"
+image_path: "images/posts/generated/gpt-54-nano-api.png"
+sponsored_at: null
+---
+## What this GPT-5.4 nano guide covers
+
+OpenAI released GPT-5.4 nano on March 17, 2026 in its [launch post](https://openai.com/index/introducing-gpt-5-4-mini-and-nano/). The current [GPT-5.4 nano model page](https://developers.openai.com/api/docs/models/gpt-5.4-nano) places it in the new GPT-5.4 family, and the current [pricing page](https://openai.com/api/pricing/) puts it at the low end of that lineup.
+
+That makes GPT-5.4 nano the model I would reach for when the job is small, repetitive, and high-volume: classification, extraction, ranking, and lightweight routing to sub-agents. OpenAI also says it is a significant upgrade over GPT-5 nano.
+
+This guide uses the pinned snapshot `gpt-5.4-nano-2026-03-17`.
+
+By the end, you will have:
+
+- a first successful GPT-5.4 nano Responses API call
+- a strict JSON routing workflow that can send work to the right sub-agent
+
+If you want the fuller GPT-5.4 picture first, start with my [GPT-5.4 API guide](/gpt-54-api). If you are coming from the older family, compare this with [GPT-5 nano](/gpt-5-nano-api).
+
+## Get your API key ready
+
+You need an OpenAI account, a funded API project, and an API key from the [API keys page](https://platform.openai.com/api-keys). Keys are shown once, so save yours right away.
+
+Then export it in your terminal.
+
+macOS and Linux:
+
+```bash
+export OPENAI_API_KEY="sk-..."
+```
+
+Windows Command Prompt:
+
+```cmd
+setx OPENAI_API_KEY "sk-..."
+```
+
+If you use `setx`, open a new terminal before testing the key.
+
+## Send your first GPT-5.4 nano request
+
+GPT-5.4 nano uses the same Responses API shape as the rest of the GPT-5.4 family, so the first request stays simple:
+
+```bash
+curl -s https://api.openai.com/v1/responses \
+  -H "Authorization: Bearer $OPENAI_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "gpt-5.4-nano-2026-03-17",
+    "input": [
+      {
+        "role": "user",
+        "content": [
+          { "type": "input_text", "text": "Say hello in one short sentence." }
+        ]
+      }
+    ],
+    "text": {
+      "verbosity": "low"
+    },
+    "max_output_tokens": 80
+  }'
+```
+
+That exact request completed successfully for me and returned `Hello!`.
+
+## Build something useful: route work to sub-agents
+
+Nano is not where I would start for a long, nuanced response draft. It is where I would start for short, repeatable jobs that need a clean handoff.
+
+Imagine your app receives this instruction:
+
+```text
+Check the pricing copy, fix the headline if needed, and flag anything risky.
+```
+
+You want GPT-5.4 nano to:
+
+1. classify the request
+2. choose the right sub-agent
+3. set a priority
+4. return a short handoff note
+
+That is a very good fit for nano because the output is narrow, structured, and easy to validate.
+
+## Return strict JSON with a schema
+
+```bash
+curl -s https://api.openai.com/v1/responses \
+  -H "Authorization: Bearer $OPENAI_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "gpt-5.4-nano-2026-03-17",
+    "instructions": "You route small tasks to the right sub-agent for a SaaS app. Be cautious. Do not promise changes that were not requested. Keep handoff_note to 2 short sentences.",
+    "input": [
+      {
+        "role": "user",
+        "content": [
+          {
+            "type": "input_text",
+            "text": "Check the pricing copy, fix the headline if needed, and flag anything risky."
+          }
+        ]
+      }
+    ],
+    "text": {
+      "verbosity": "low",
+      "format": {
+        "type": "json_schema",
+        "name": "sub_agent_routing",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "destination_agent": {
+              "type": "string",
+              "enum": ["copy_agent", "seo_agent", "legal_agent", "general_agent"]
+            },
+            "priority": {
+              "type": "string",
+              "enum": ["low", "medium", "high"]
+            },
+            "needs_human": {
+              "type": "boolean"
+            },
+            "handoff_note": {
+              "type": "string"
+            }
+          },
+          "required": ["destination_agent", "priority", "needs_human", "handoff_note"],
+          "additionalProperties": false
+        },
+        "strict": true
+      }
+    },
+    "max_output_tokens": 200
+  }'
+```
+
+That kind of output is easy to plug into a dispatcher:
+
+- `destination_agent` picks the next sub-agent
+- `priority` changes queue order
+- `needs_human` can stop unsafe automation
+- `handoff_note` gives the next model a clean starting point
+
+If you want to move the same pattern into PHP afterward, my guide on [using OpenAI's API in PHP with openai-php/client](/openai-php-client) picks up right there.
+
+## Why GPT-5.4 nano is different
+
+GPT-5.4 nano is not just a smaller model. It is the one I would choose when cost and throughput matter more than broad reasoning.
+
+OpenAI's pricing page puts it at the low end of the GPT-5.4 family, which is why it makes sense for:
+
+- classification
+- data extraction
+- ranking
+- routing to sub-agents
+- preprocessing before a stronger model sees the hard cases
+
+That also makes it a natural step up from the older [GPT-5 nano guide](/gpt-5-nano-api) when you want the newer GPT-5.4 family without jumping all the way to full GPT-5.4.
+
+## How I would choose reasoning effort on GPT-5.4 nano
+
+For nano, I would start with:
+
+- `minimal` for almost everything
+- `low` when the task needs a little more judgment
+- `medium` only when the prompt is still small but the answer quality is not quite there yet
+
+The key is to keep the task compact. Nano shines when the job is precise, not when it needs a long chain of reasoning.
+
+## When GPT-5.4 nano is the right model
+
+Pick GPT-5.4 nano when you care about:
+
+- very high request volume
+- low latency
+- low cost
+- strict structured output
+- lightweight routing before a bigger model or a human steps in
+
+If the task starts needing broader judgment, [GPT-5.4](/gpt-54-api) is the more capable next stop. If the task stays simple but you want the older family, [GPT-5 nano](/gpt-5-nano-api) is still a useful comparison point.
+
+## Common mistakes with GPT-5.4 nano
+
+### 1. Expecting it to behave like the flagship model
+
+Nano is great at small, repeatable tasks. It is not where I would start for open-ended analysis.
+
+### 2. Using long reply-drafting workflows by default
+
+Nano works best when the output is short and predictable.
+
+### 3. Forgetting to route hard cases onward
+
+Nano is strongest when it filters, labels, or dispatches. It does not need to do everything itself.
+
+If GPT-5.4 nano looks close to what you need, these are the next reads I would keep open:
+
+- [See the full GPT-5.4 API quick start for the flagship family](/gpt-54-api)
+- [Compare it with the older GPT-5 nano quick start](/gpt-5-nano-api)
+- [See the cheaper GPT-5 mini workflow for broader low-cost tasks](/gpt-5-mini-api)
+- [Move this same structured-output pattern into PHP](/openai-php-client)


### PR DESCRIPTION
## Summary
- add a new GPT-5.4 mini API quick start post
- add a new GPT-5.4 nano API quick start post
- fix sourcing and sibling links so both posts point to the official GPT-5.4 launch/model pages

## Verification
- php artisan app:sync-posts

## Notes
- tried to regenerate featured images, but browsershot/Chromium could not launch in the sandbox