### PR TITLE
Add community links Atom feed

### DIFF
--- a/app/Models/Link.php
+++ b/app/Models/Link.php
@@ -2,6 +2,8 @@
 
 namespace App\Models;
 
+use Spatie\Feed\Feedable;
+use App\Models\Traits\LinkFeedable;
 use App\Notifications\LinkApproved;
 use Database\Factories\LinkFactory;
 use App\Models\Traits\LinkSearchable;
@@ -15,10 +17,10 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 /**
  * Represents link records.
  */
-class Link extends Model
+class Link extends Model implements Feedable
 {
     /** @use HasFactory<LinkFactory> */
-    use HasFactory, LinkSearchable;
+    use HasFactory, LinkFeedable, LinkSearchable;
 
     protected function casts() : array
     {

--- a/app/Models/Traits/LinkFeedable.php
+++ b/app/Models/Traits/LinkFeedable.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Models\Traits;
+
+use App\Models\Link;
+use Spatie\Feed\FeedItem;
+use App\Markdown\MarkdownRenderer;
+use Illuminate\Support\Collection;
+
+/**
+ * @mixin Link
+ */
+trait LinkFeedable
+{
+    public static function getFeedItems() : Collection
+    {
+        return static::query()
+            ->approved()
+            ->latest('is_approved')
+            ->limit(50)
+            ->get();
+    }
+
+    public function toFeedItem() : FeedItem
+    {
+        return FeedItem::create()
+            ->id(route('links.index') . '#link-' . $this->getKey())
+            ->title($this->title)
+            ->summary(MarkdownRenderer::parse($this->description ?? ''))
+            ->updated($this->is_approved)
+            ->link($this->url)
+            ->authorName($this->user->name);
+    }
+}

--- a/config/feed.php
+++ b/config/feed.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Models\Link;
 use App\Models\Post;
 
 return [
@@ -51,6 +52,18 @@ return [
              * The content type for the feed response. Set to an empty string to automatically
              * determine the correct value.
              */
+            'contentType' => '',
+        ],
+        'links' => [
+            'items' => [Link::class, 'getFeedItems'],
+            'url' => '/links/feed',
+            'title' => config('app.name') . ' community links',
+            'description' => 'Latest community links from ' . config('app.name'),
+            'language' => 'en-US',
+            'image' => '',
+            'format' => 'atom',
+            'view' => 'feed::atom',
+            'type' => '',
             'contentType' => '',
         ],
     ],

--- a/config/feed.php
+++ b/config/feed.php
@@ -58,7 +58,7 @@ return [
             'items' => [Link::class, 'getFeedItems'],
             'url' => '/links/feed',
             'title' => config('app.name') . ' community links',
-            'description' => 'Latest community links from ' . config('app.name'),
+            'description' => 'Latest community links from benjamincrozat.com',
             'language' => 'en-US',
             'image' => '',
             'format' => 'atom',

--- a/tests/Feature/App/Models/LinkTest.php
+++ b/tests/Feature/App/Models/LinkTest.php
@@ -3,6 +3,7 @@
 use App\Models\Link;
 use App\Models\Post;
 use App\Models\User;
+use Spatie\Feed\FeedItem;
 use Carbon\CarbonImmutable;
 use App\Notifications\LinkApproved;
 use Illuminate\Support\Facades\Notification;
@@ -162,4 +163,38 @@ it('maps searchable attributes and only indexes approved links', function () {
     ]);
 
     expect($pendingLink->shouldBeSearchable())->toBeFalse();
+});
+
+it('getFeedItems only returns the 50 most recently approved links', function () {
+    Link::factory(60)->approved()->create();
+    Link::factory()->create([
+        'is_approved' => null,
+        'is_declined' => null,
+    ]);
+    Link::factory()->declined()->create();
+
+    $feedItems = Link::getFeedItems();
+
+    expect($feedItems)->toHaveCount(50);
+    expect($feedItems->first()->is_approved->greaterThanOrEqualTo($feedItems->last()->is_approved))->toBeTrue();
+    expect($feedItems->every(fn (Link $link) => $link->isApproved()))->toBeTrue();
+});
+
+it('converts a link to a valid FeedItem via toFeedItem()', function () {
+    $user = User::factory()->create(['name' => 'John Doe']);
+
+    $link = Link::factory()->for($user)->approved()->create([
+        'title' => 'Foo',
+        'description' => 'Bar',
+        'url' => 'https://example.com/foo',
+    ]);
+
+    $feedItem = $link->toFeedItem();
+
+    expect($feedItem)->toBeInstanceOf(FeedItem::class)
+        ->and($feedItem->id)->toBe(route('links.index') . '#link-' . $link->id)
+        ->and($feedItem->title)->toBe('Foo')
+        ->and($feedItem->link)->toBe('https://example.com/foo')
+        ->and($feedItem->authorName)->toBe('John Doe')
+        ->and($feedItem->summary)->toContain('Bar');
 });

--- a/tests/Feature/FeedTest.php
+++ b/tests/Feature/FeedTest.php
@@ -26,3 +26,24 @@ it('lists the latest 50 posts that are not associated to a link and shows the de
         $response->assertDontSee($post->content);
     });
 });
+
+it('lists the latest approved community links in the Atom feed', function () {
+    $approvedLinks = Link::factory(30)->approved()->create();
+
+    Link::factory()->create([
+        'is_approved' => null,
+        'is_declined' => null,
+    ]);
+
+    Link::factory()->declined()->create();
+
+    $response = get(route('feeds.links'))
+        ->assertOk();
+
+    $approvedLinks->each(function (Link $link) use ($response) {
+        $response->assertSee($link->title, escape: false);
+        $response->assertSee($link->description, escape: false);
+        $response->assertSee($link->url);
+        $response->assertSee($link->user->name, escape: false);
+    });
+});


### PR DESCRIPTION
## Summary
- add a dedicated Atom feed for approved community links at 
- make  feedable through a small  trait
- add coverage for feed item mapping and the feed response

## Verification
- 
  Environment ................................................................  
  Application Name ........................................... Benjamin Crozat  
  Laravel Version .................................................... 12.54.1  
  PHP Version ......................................................... 8.4.16  
  Composer Version ..................................................... 2.9.3  
  Environment .......................................................... local  
  Debug Mode ......................................................... ENABLED  
  URL ........................................................... blog-v5.test  
  Maintenance Mode ....................................................... OFF  
  Timezone ............................................................... UTC  
  Locale .................................................................. en  
- {"result":"pass"}
- 
 [OK] No errors                                                                 
- browser check against 
   WARN  Unable to respect the `PHP_CLI_SERVER_WORKERS` environment variable without the `--no-reload` flag. Only creating a single server.  

   INFO  Server running on [http://127.0.0.1:8017].  

  Press Ctrl+C to stop the server

  2026-03-18 12:40:56 /preview/posts/gpt-54-mini-api/image ....... ~ 507.77ms
- 
  GET|HEAD       feed ........... feeds.main › Spatie\Feed\Http\FeedController
  GET|HEAD       links/feed .... feeds.links › Spatie\Feed\Http\FeedController

                                                            Showing [2] routes
- in-process requests confirmed  returns  and  advertises  in the head

## Note
- 
  [44;1m INFO [49;22m Test file "..." not found. is currently blocked in this worktree because Pest derives an invalid namespace from the numeric worktree path segment ().