### PR TITLE
Tighten agent docs and clarify worktree PR flow

### DIFF
--- a/.agents/skills/file-first-posts/SKILL.md
+++ b/.agents/skills/file-first-posts/SKILL.md
@@ -7,54 +7,36 @@ metadata:
 
 # File-first Posts
 
-## Scope
+## Trigger
 
-Use this skill when posts are managed from `resources/markdown/posts`.
-Pair with `post-writing` when revising copy, and with `seo-content` when search framing matters.
+Use this skill for `resources/markdown/posts`. Pair with `post-writing` for copy and `seo-content` for search framing.
 
-## Required Rules
+## Rules
 
-- Treat Markdown files as the only write source for post content and SEO fields.
+- Markdown files are the only write source for post content and SEO fields.
 - Use `php artisan app:export-posts` only for initial export or explicit regeneration.
-- Use `php artisan app:sync-posts` after every Markdown edit.
-- Upload every image used in a post to Cloudflare Images, including featured images, inline screenshots, badges, logos, and comparison cards.
-- Use `php artisan app:upload-post-image` for post images instead of local paths or third-party hotlinks.
-- If a post still has no featured image once the draft is written, run `php artisan app:generate-post-image your-post-slug` so `image_disk` / `image_path` are filled before handoff or publishing.
-- When a post explains an interface, setup flow, settings page, terminal output, or before/after result, prefer creating original screenshots instead of leaving the visual outcome implied.
-- Skip screenshots only when they add no proof or clarity.
-- Give screenshot files descriptive names and useful alt text before upload.
-- Use UTC ISO-8601 timestamps with a trailing `Z` for frontmatter dates such as `published_at` and `modified_at`. Treat `Z` as the only canonical UTC format in this repo; do not use `+00:00`.
-- Publishing is changing `published_at` in the file, then running `php artisan app:sync-posts`.
-- If `categories` includes `news`, publish promptly, sync immediately after substantive edits, and only set `modified_at` when the article changed in a meaningful reporting way.
-- Only first-party, non-commercial, non-sponsored `news` posts should be treated as news-sitemap candidates.
+- Run `php artisan app:sync-posts` after every Markdown edit unless the last step was `php artisan app:generate-post-image`, which already syncs.
+- Upload every image with `php artisan app:upload-post-image`; no local paths or third-party hotlinks.
+- If the featured image is still missing after the draft is stable, run `php artisan app:generate-post-image <slug>`.
+- Prefer original screenshots when they materially prove or clarify UI, setup, output, or before/after results. Skip filler.
+- Use UTC ISO-8601 timestamps with trailing `Z` only. Normalize any `+00:00` back to `Z`.
+- Publishing is `published_at` in the file, then sync.
+- `news` posts: publish promptly, sync after substantive edits, and set `modified_at` only for meaningful reporting changes.
+- Only first-party, non-commercial, non-sponsored `news` posts are news-sitemap candidates.
 - Fail loudly on invalid front matter, unknown authors/categories, or duplicate IDs/slugs.
 - Do not use Filament to create, edit, delete, or restore posts.
-- If an edit changes article copy or scope, refresh internal links and, for non-commercial posts, the related-posts list before syncing.
+- If copy or scope changed, refresh internal links and, for non-commercial posts, the related-posts block before syncing.
+- Non-commercial posts need one related-posts block with a custom lead-in ending with `:` and contextual anchors chosen as true next reads.
 - Commercial posts (`is_commercial: true`) must not include a related-posts or read-next block.
-- Non-commercial related-posts blocks must use a custom article-specific lead-in sentence ending with a colon, followed by clear, contextual anchors rather than pasted destination titles.
-- Pick related posts because they are the best next reads for this article, not because they share a category.
-- Do not open the public page or Filament just for a routine post edit. Use browser checks only when the post includes tricky rendering, embeds, custom HTML, unusual formatting, interactive behavior, a publishing-state change that needs confirmation, the article needs purposeful screenshots that materially help the reader, or the user explicitly asks for a visual check.
+- Skip browser checks for routine Markdown edits. Use them only for tricky rendering, embeds, custom HTML, unusual formatting, interactive behavior, publishing-state checks, purposeful screenshots, or explicit requests.
 
-## Workflow
+## Flow
 
-1. Bootstrap files when needed:
-   - run `php artisan app:export-posts`
-2. Edit the target file in `resources/markdown/posts`.
-   - if article copy changed, update internal links and, for non-commercial posts, add or refresh the related-posts list with a natural lead-in that does not quote or rephrase the title
-3. Capture and upload images before syncing:
-   - if the article would be clearer or more trustworthy with original screenshots, capture them yourself when feasible instead of leaving a note for later
-   - every image referenced by the post should end up on Cloudflare Images, not just the hero image
-   - for posts aiming at Discover or Google News strongly, the main image should be original when feasible, not a logo, and at least 1200 px wide
-   - hero image: `php artisan app:upload-post-image /absolute/path/to/cover.png --markdown=your-post.md`
-   - inline image: `php artisan app:upload-post-image /absolute/path/to/step.png --alt="Describe the screenshot"` and paste the returned URL into the article body
-   - if the post still has no featured image after writing it, generate one with `php artisan app:generate-post-image your-post-slug`
-4. If publishing state changes, update `published_at` in UTC with a trailing `Z`.
-   - if this is a news post and you made a substantive reporting update, set `modified_at` in UTC with a trailing `Z` before syncing
-5. Run `php artisan app:sync-posts`.
-   - skip this extra sync only when the last action was `php artisan app:generate-post-image`, because that command already updates the Markdown file and runs `php artisan app:sync-posts` for you
-   - if `php artisan app:sync-posts` or `php artisan app:generate-post-image` rewrites timestamps to `+00:00`, normalize them back to the repo standard `Z` format before finishing
-6. Decide whether a browser check is needed:
-   - skip it for routine Markdown-only edits when `php artisan app:sync-posts` succeeds
-   - open the public page or Filament only for tricky rendering, embeds, custom HTML, unusual formatting, interactive behavior, or publishing changes that need confirmation
-7. Keep deploy notes in mind:
-   - deployment should run `php artisan app:sync-posts` before sitemap generation
+1. Export only when the file does not exist yet or the user explicitly wants regeneration.
+2. Edit `resources/markdown/posts/<slug>.md`.
+3. If copy or scope changed, refresh internal links and the related-posts block when allowed.
+4. Capture and upload needed images. For Discover/News-focused posts, the main image should be original when feasible and at least 1200 px wide.
+5. Update `published_at` / `modified_at` when needed.
+6. Run `php artisan app:sync-posts` or `php artisan app:generate-post-image <slug>`.
+7. Only use browser validation when the article needs it.
+8. Keep deploy behavior in mind: deployment should sync posts before sitemap generation.

--- a/.agents/skills/framework-news-analysis/SKILL.md
+++ b/.agents/skills/framework-news-analysis/SKILL.md
@@ -7,31 +7,24 @@ metadata:
 
 # Framework News Analysis
 
-## Scope
+## Trigger
 
-Use when the task is to find, frame, and write the strongest weekly news or analysis post about a framework, library, tool, platform, or developer product.
+Use for weekly news or analysis posts about a framework, library, tool, platform, or developer product. Pair with `post-writing`, `file-first-posts`, and `seo-content`.
 
-Pair with `post-writing`, `file-first-posts`, and `seo-content` for drafting, publishing, and search framing.
+## Rules
 
-## Required Rules
+- Start with current primary sources: release notes, changelogs, docs, official blog posts, and product announcements.
+- Pick the shape before drafting: straight news, reported analysis, or review with opinion.
+- Separate reporting from opinion. Opinion should clarify stakes, not perform a persona.
+- If the news is thin, narrow the angle instead of inflating it.
+- If the story is bigger than one release, look for official examples that show the wider shift.
+- If the strongest claim depends on behavior rather than wording, test it when cheap and useful.
+- Explain who should care, who probably should not, and the practical next step.
 
-- Start with current primary sources: official release notes, changelogs, docs, blog posts, and product announcements.
-- Decide the shape before drafting: straight news, reported analysis, or review with opinion.
-- Separate reporting from opinion. Opinion should clarify the stakes, not perform a persona.
-- Stay skeptical of hype. If the news is thin, narrow the angle instead of inflating the claim.
-- When the story is bigger than one release, look for official examples that show the surrounding market or ecosystem shift.
-- If the strongest claim depends on behavior rather than wording, test it when that is cheap and useful.
-- Explain who should care, who probably should not, and what practical next step follows from the news.
-- Prefer honest angles like "real but narrower than the hype" over louder framing that the reporting cannot support.
+## Flow
 
-## Workflow
-
-1. Identify the topic from the user's request.
-2. Gather primary sources for this week first, then only widen out when the story clearly needs more context.
-3. Choose the strongest angle:
-   - direct release/update news
-   - broader ecosystem or enterprise analysis
-   - review/opinion grounded in the official material
-4. Pressure-test the angle:
-   - would this inform a competent developer, or just repeat buzzwords?
-5. Hand off to `post-writing`, `file-first-posts`, and `seo-content` for the actual article work.
+1. Identify the topic.
+2. Gather current primary sources for this week first.
+3. Choose the strongest angle: direct release/update, broader ecosystem analysis, or review/opinion grounded in the official material.
+4. Pressure-test the angle: would it inform a competent developer, or just repeat buzzwords?
+5. Hand off to `post-writing`, `file-first-posts`, and `seo-content` for drafting, publishing, and search framing.

--- a/.agents/skills/post-writing/SKILL.md
+++ b/.agents/skills/post-writing/SKILL.md
@@ -7,108 +7,62 @@ metadata:
 
 # Post Writing
 
-## Scope
+## Trigger
 
-Use for drafting or revising publication-ready posts in `resources/markdown/posts`.
-Pair with `seo-content` for search intent, Discover/News judgment, titles, snippets, and internal linking.
+Use for publication-ready posts in `resources/markdown/posts`. Pair with `seo-content` for search framing and `file-first-posts` for sync, publish, and image workflow.
 
 ## Frontmatter Contract
 
 - Required keys: `id`, `title`, `slug`, `author`, `description`, `categories`.
-- Keep `id` stable when revising an existing post.
-- `author` must use the author's `github_login`.
-- `categories` must use category slugs.
-- `published_at`, `modified_at`, and `sponsored_at` use UTC ISO-8601 datetimes with a `Z` suffix or `null`.
-- Treat the `Z` suffix as the only canonical UTC format for frontmatter timestamps in this repo. Do not use `+00:00` when writing or normalizing dates.
+- Keep `id` stable on revisions.
+- `author` uses the author's `github_login`; `categories` use category slugs.
+- `published_at`, `modified_at`, and `sponsored_at` are UTC ISO-8601 datetimes with trailing `Z` or `null`.
 - `serp_title`, `serp_description`, `canonical_url`, `image_disk`, and `image_path` are nullable strings.
-- `serp_title` overrides the HTML `<title>` tag and `serp_description` overrides the meta description tag.
 - `is_commercial` must be `true` or `false`.
 - The filename must match `slug` and end in `.md`.
 
-## Required Rules
+## Rules
 
 - Write for competent beginners first: plain language, short sentences, clear payoff.
-- Explain unavoidable technical terms in simple words the first time they appear.
-- Upload every image used in the post to Cloudflare Images with `php artisan app:upload-post-image`, including featured images, inline screenshots, badges, logos, and comparison cards.
-- Do not leave local file paths or third-party hotlinked images in post Markdown.
-- For walkthroughs, dashboards, UI-heavy how-tos, comparisons, and reviews, actively look for places where an original screenshot, crop, or simple visual would make the article clearer or more credible.
-- Create those visuals yourself when feasible instead of leaving a TODO or only describing the interface in prose.
-- Use visuals as proof and clarification, not decoration. Skip them when the topic is conceptual, code-first, or the image would only repeat the nearby text.
-- Give every kept visual a descriptive filename, place it near the relevant text, and write useful alt text before uploading it to Cloudflare Images.
-- Keep the promise tight across frontmatter: `title`, `description`, `slug`, and any `serp_*` overrides should point to the same outcome.
-- Do not add an in-body H1 or a manual table of contents.
-- Draft at least five title options, then pick the clearest one.
-- Use sentence case for titles by default. For search-facing titles, roughly 40-60 characters or 6-9 words is a useful soft target, not a hard rule.
-- Prefer titles with a plain-language outcome over clever phrasing or vague filler.
-- Treat `title` as the visible article title and `description` as the default summary used across the site.
-- Default `serp_title` and `serp_description` to `null`. Set them only when a tighter search/browser variant is clearly better than the default.
-- If `serp_title` is set, keep it very close to the visible `title` in meaning. It can be shorter or slightly more descriptive, but it must not target a different angle, query, or claim.
-- If `serp_description` is set, make it a concise, accurate summary of the same page. Do not use keyword lists or add claims that the page does not support.
-- When choosing among title options, favor the one with the clearest benefit, strongest specificity, and best query match.
-- Descriptions should read like a useful pitch for the page: one short sentence or two short clauses, with the main benefit near the start.
-- If the topic is time-sensitive, you may use a year or date, but only if the page itself is current enough to support it.
-- If `categories` includes `news`, treat the draft as a news post: lead with the new information, verify claims with primary sources, attribute those sources inline, keep the structure tight, and avoid padding it into an evergreen explainer.
-- For posts intended to target Google News or Discover strongly, the primary article image should be original when feasible, not a logo, and at least 1200 px wide.
-- Once the post copy and title are stable, make sure the post has a featured image. If `image_disk` / `image_path` are still empty, generate one with `php artisan app:generate-post-image your-post-slug` before finishing.
-- For evergreen posts meant to compete in Discover, sharpen the opening payoff and framing, but do not force a news structure onto the draft.
-- Avoid clickbait phrasing, vague curiosity hooks, fake urgency, unsupported superlatives, emojis, or decorative all-caps.
-- Open fast: explain the problem, answer, or reason to care in the first few paragraphs.
-- Keep headings descriptive and skimmable. Use the exact primary keyword in only 1-2 headings if it reads naturally.
-- Prefer practical examples and code when they help, but never leave a section as code-only.
-- Add context before snippets and explain what they do, why they matter, and what result to expect.
-- Use current primary sources for version-sensitive claims. Link inline at the claim, and prefer relevant internal links before equivalent external links.
-- Keep the article body reader-facing. Do not mention your drafting workflow, prompts, temp projects, verification steps, or that you followed internal instructions or skills inside the post copy. If first-hand use materially matters, report the result in plain reader terms rather than narrating your behind-the-scenes process.
-- Avoid filler judgments in post copy such as "feels real", "feels natural", "feels polished", or similar vibe-based phrasing unless you are quoting or attributing a sourced opinion.
-- Every created or revised non-commercial post must include a short list of interesting posts to read next. If the post already has one, refresh it instead of duplicating it.
-- Commercial posts (`is_commercial: true`) must not include a related-posts, read-next, or follow-up reading block. Keep the ending focused on the conversion path already present in the article.
-- On non-commercial posts, use a custom article-specific lead-in sentence ending with a colon, then a standard Markdown list with one linked item per bullet, like this:
-  Custom lead-in text for this specific article:
-
-  - [Highly specific anchor text](/target-slug)
-  - [Another highly specific anchor text](/another-target)
-- Do not quote or lightly rephrase the article title in that lead-in.
-- Do not copy the destination post title as anchor text by default. Rewrite each anchor so it fits the current article's context, stays accurate, and makes the next click obvious.
-- Favor clarity over cleverness. If an anchor sounds vague, ambiguous, or too cute, rewrite it in plainer language.
-- Add as many recommendations as the topic honestly supports on non-commercial posts: usually at least 3, sometimes more, with a hard cap of 10. Do not pad the list with weak matches.
-- Pick recommended posts that genuinely extend the topic for this exact reader journey. Use editorial judgment, not category matching or obvious heuristics. You do not need to fully read every recommended post before linking it, but you should believe the recommendation makes sense.
-- When creating or revising a post, add or improve natural internal links in the body wherever a reader would want the next step, not only in the closing list.
+- Explain unavoidable technical terms the first time they appear.
+- Upload every image with `php artisan app:upload-post-image`; no local paths or hotlinks.
+- Create original visuals for walkthroughs, dashboards, UI-heavy how-tos, comparisons, and reviews when they materially add proof or clarity. Skip filler.
+- Keep `title`, `description`, `slug`, and any `serp_*` override aligned on one promise.
+- No in-body H1. No manual table of contents.
+- Draft at least five title options, then choose the clearest one.
+- Use sentence case by default. A 40-60 character or 6-9 word title is a soft heuristic, not a hard rule.
+- Leave `serp_title` and `serp_description` as `null` unless a tighter search/browser variant is clearly better while keeping the same angle.
+- Use dates or years only when the page is current enough to support them.
+- `news` posts should lead with the update, cite primary sources inline, and stay tight.
+- Open fast. Keep headings descriptive. Use the primary keyword naturally, not repetitively.
+- Add context before code. Do not leave sections as code-only.
+- Use current primary sources for version-sensitive claims. Prefer relevant internal links before equivalent external links.
+- Keep the article body reader-facing. Do not mention internal workflow, prompts, temp projects, or skills inside the post.
+- Avoid vague vibe words unless quoting or attributing a source.
+- Non-commercial posts need one related-posts list with a custom lead-in ending with `:` and contextual anchors. Usually add at least 3 items; never more than 10.
+- Commercial posts (`is_commercial: true`) must not include a related-posts, read-next, or follow-up reading block.
+- Pick related posts because they genuinely extend this reader journey, not because they share a category.
+- Add or improve natural internal links in the body wherever a reader wants the next step.
 - Verify links and commands when feasible. If something cannot be verified, tell the user outside the post copy.
-- When setting frontmatter timestamps, use UTC rather than the machine's local timezone, and write them with a trailing `Z`.
-- Skip browser-based validation for routine post-writing tasks. Only use it when the post has tricky rendering, embeds, custom HTML, unusual formatting, interactive behavior, the article needs first-hand screenshots that materially help the reader, or the user explicitly asks for a visual check.
+- Use UTC timestamps with trailing `Z`.
+- If the featured image is missing when the copy is stable, run `php artisan app:generate-post-image <slug>`.
+- Skip browser validation for routine post-writing tasks. Use it only for tricky rendering, embeds, custom HTML, unusual formatting, interactive behavior, first-hand screenshots that materially help the reader, or explicit requests.
 
 ## Common Shapes
 
-- Fix post:
-  state the problem quickly, explain the likely cause, show the fix, and close with edge cases or alternatives.
-- Concept post:
-  define the idea in simple words, show why it matters, then teach through examples and gotchas.
-- News post:
-  lead with the update, explain why it matters now, attribute the primary sources inline, add only the context needed to understand the change, and close with 2-4 durable links into relevant evergreen posts.
+- Fix post: state the problem, explain the cause, show the fix, then note edge cases or alternatives.
+- Concept post: define the idea simply, explain why it matters, then teach through examples and gotchas.
+- News post: lead with the update, explain why it matters now, cite primary sources inline, and close with a few durable evergreen links.
 
-## Workflow
+## Flow
 
-1. Define the reader promise, search intent, and whether this is an evergreen post, a news post, or a broader Discover candidate.
-2. Draft five or more title candidates and choose the strongest one.
-3. Decide whether `serp_title` or `serp_description` need an override; otherwise leave them `null`.
-4. Check that the chosen title and description earn the click with a clear outcome, not a gimmick.
-5. Pick the simplest outline that matches the post shape, and keep it tighter when the post is news.
-6. Draft for clarity, usefulness, and brevity.
-7. Decide whether original screenshots or simple visuals would materially clarify the piece or prove first-hand use; create them when the answer is yes.
-8. If the post still has no featured image after the copy is stable, run `php artisan app:generate-post-image your-post-slug`. If you intentionally need a fresh render for an existing generated image, use `--force`.
-9. Add or refresh contextual internal links and, for non-commercial posts, the related-posts list.
-10. Validate version-sensitive claims, inline links, and code examples.
-11. Do a final publishing pass:
-   - required frontmatter is present and valid
-   - existing post IDs stayed unchanged
-   - the post has a featured image, whether custom-uploaded or generated through `php artisan app:generate-post-image`
-   - every image used in the post, including featured images and inline assets, uses Cloudflare Images URLs or paths
-   - screenshots or simple visuals were added when they materially improved clarity, credibility, or first-hand evidence, and skipped when they would have been filler
-   - frontmatter promise is aligned
-   - `serp_title` and `serp_description` are either `null` or clearly justified and aligned with the visible page copy
-   - title and description make a strong, accurate click promise
-   - headings read naturally in the generated table of contents
-   - contextual internal links were added or improved where helpful
-   - non-commercial posts have one up-to-date related-posts list with a custom lead-in that does not echo the title and anchor text that is contextual rather than a pasted destination title
-   - commercial posts do not include a related-posts, read-next, or follow-up reading block
-   - code and links support the nearby claim
-   - all frontmatter timestamps use the repo's canonical UTC format with a trailing `Z`, not `+00:00`
+1. Define the reader promise, search intent, and post shape.
+2. Draft at least five title candidates and choose the strongest one.
+3. Decide whether `serp_title` or `serp_description` should stay `null` or get a same-angle override.
+4. Pick the simplest outline that fits the post shape.
+5. Draft for clarity, usefulness, and brevity.
+6. Create original visuals only when they materially clarify the piece or prove first-hand use.
+7. If the post still has no featured image after the copy is stable, run `php artisan app:generate-post-image <slug>`. Use `--force` only when you intentionally need a fresh render.
+8. Add or refresh contextual internal links and, for non-commercial posts, the related-posts list.
+9. Validate version-sensitive claims, inline links, and code examples.
+10. Final pass: frontmatter valid, `id` stable, promise aligned, featured image present, all images on Cloudflare, `serp_*` aligned or `null`, related-posts rules respected, and timestamps use `Z`.

--- a/.agents/skills/seo-content/SKILL.md
+++ b/.agents/skills/seo-content/SKILL.md
@@ -7,89 +7,51 @@ metadata:
 
 # SEO Content
 
-## Scope
+## Trigger
 
-Use alongside `post-writing` for new or existing publication-ready posts, or on its own when the user gives keywords and wants SERP or competitor analysis.
+Use with `post-writing` for publication-ready posts, or alone when the user wants keyword, SERP, or competitor analysis.
 
-Read these references as needed:
-- `references/google-2026.md` for current Google guidance
-- `references/google-news.md` for Google News and Discover guidance
-- `references/competitive-reality.md` for field evidence and grey-hat risk
-- `references/serp-analysis.md` for the keyword and top-3 competitor workflow
+Read references only when needed:
+- `references/google-2026.md`
+- `references/google-news.md`
+- `references/competitive-reality.md`
+- `references/serp-analysis.md`
 
-## Required Rules
+## Rules
 
-- Use live search results for any keyword, SERP, or ranking-sensitive decision. Do not rely on memory for current rankings.
-- Use Google for competitor checks, not a generic search engine result feed.
-- If the user gives one or more keywords, inspect the current Google SERP and analyze the top 3 organic results before drafting.
-- Use the browser MCP when Google’s real SERP layout, ranking order, or feature mix matters.
-- When revising an existing post, compare the current page promise against the live Google SERP before changing titles, headings, slug, or angle.
-- Use competitors to understand coverage, framing, freshness, and content gaps, not as the main factual basis for our article.
-- For facts, version details, policies, benchmarks, and product behavior, prefer official documentation, release notes, specifications, direct testing, or other primary sources.
-- If a useful claim appears in competitor content, verify it independently before reusing it.
-- Identify dominant search intent before writing: fix, definition, comparison, tool choice, list, landing page, or mixed intent.
-- Build around intent plus one clear differentiator. Do not copy a competitor's structure unless you are improving it.
-- Keep `title`, `description`, `slug`, intro, and first useful section aligned on the same promise.
-- Default to the same core promise for visible page copy and search-facing metadata. Use `serp_title` and `serp_description` only for intentional overrides, not as a second editorial angle.
-- `serp_title` is an HTML `<title>` override, not a guaranteed Google-only title. Keep it close to the visible title so Google sees one clear main title.
-- `serp_description` is a meta description override. Use it only when it improves on `description` as a page summary; Google may ignore or rewrite it by query.
-- There is no hard Google character limit for titles or meta descriptions. Both are truncated to fit device width, so use length as a heuristic, not a rule.
-- For CTR, prefer a concrete outcome, strong query match, and a clear differentiator over clever phrasing.
-- As a soft title heuristic, aim for roughly 40-60 characters or 6-9 words when possible. Break that range when extra specificity meaningfully improves relevance or trust.
-- Front-load the primary query match and main payoff early in the title, because the start of the title is the most consistently visible part.
-- For function-led or helper-led tutorials, prefer natural task-led titles over bare keyword labels. A good pattern is `How to <outcome> in <language> with <function>()` when the function name adds clarity without making the title stiff.
-- Do not force an exact-match head term into the visible title if it makes the title read like a search query. Keep the search intent intact, but write for humans first.
-- For custom descriptions, put the main benefit and query match in the first ~120 characters. A one-sentence summary often lands around 140-160 characters, but clarity matters more than hitting a count.
-- Questions are not an automatic CTR win. Positive, specific wording can help, but only when it stays natural and accurate.
-- Avoid cheap CTR bait: fake urgency, fake freshness, unsupported numbers, emoji gimmicks, or all-caps unless the query and vertical clearly support them.
-- Add a year or date only when the topic is genuinely time-sensitive and the page is actually updated to match.
-- Use the primary keyword in the title, intro, slug, and only 1-2 lower headings when natural.
-- Prefer clear, specific titles and snippets over keyword stuffing. Google may rewrite both.
-- When `categories` includes `news`, decide explicitly whether the piece is best treated as a Google News candidate, a Discover candidate, a classic Search page, or some overlap of the three.
-- News posts should prioritize primary-source attribution, visible byline/date transparency, and fast usefulness over exhaustive evergreen coverage.
-- Do not assume every news post is a Discover candidate or every Discover candidate is a news post.
-- On every new or revised post, add or refresh relevant internal links with descriptive anchors. Treat them as navigation and topical context, not filler.
-- If the query or angle is visual by nature, such as interfaces, settings, dashboards, workflows, reviews, or before/after comparisons, assume original screenshots or other first-hand visuals are part of the winning content plan unless the live SERP shows they add no value.
-- Treat original screenshots, photos, diagrams, and comparison visuals as indirect SEO support: they can improve clarity, authenticity, image-search eligibility, and AI cite-worthiness, but they are not a standalone ranking factor.
-- Do not pad conceptual posts with decorative screenshots. Add visuals only when they clarify the step, prove the claim, or strengthen the page's first-hand value.
-- For posts intended to target Discover or Google News strongly, the main image should be original when feasible, not a logo, and at least 1200 px wide.
-- Keep the post's related-posts list current as part of that internal-linking pass on non-commercial posts. Update stale recommendations or anchors when the article's angle changes instead of leaving an outdated list behind.
-- Commercial posts (`is_commercial: true`) must not include a related-posts, read-next, or follow-up reading block. Keep those pages focused on conversion rather than onward reading.
-- On non-commercial posts, the related-posts block should use a custom article-specific lead-in sentence ending with a colon, then a standard Markdown list such as `- [Very specific anchor text](/target-slug)`.
-- Do not quote or lightly rephrase the title in that lead-in.
-- Do not default to the destination post's exact title as anchor text. Rewrite anchors so they fit the current article's context, stay accurate, and make the reason to click immediately clear.
-- Keep anchor wording plain enough that the reader instantly understands why the link matters.
-- Add only the number of recommendations the topic can support on non-commercial posts: usually 3 or more, sometimes more, with a hard cap of 10. Choose them with editorial judgment based on what a reader would genuinely want next, not by category matching alone. You do not need to fully read every recommended post.
-- Keep visible content consistent with frontmatter and any structured data.
-- Any image used in the post should be hosted on Cloudflare Images rather than hotlinked from third parties.
-- For AI visibility, aim to be cite-worthy: direct answers, strong subheads, original details, and useful examples.
-- Do not use fake freshness, fake authorship, fabricated stats, doorway pages, parasite SEO, expired-domain abuse, link schemes, or scaled thin AI filler on this site.
+- Use live Google results for any keyword, SERP, or ranking-sensitive decision.
+- If keywords are supplied, inspect the live SERP and analyze the top 3 organic results before drafting.
+- Use the browser MCP when the real SERP layout, ordering, or feature mix matters.
+- On revisions, compare the current page promise against the live SERP before changing title, headings, slug, or angle.
+- Use competitors for framing, gaps, and freshness, not as the main factual basis. Verify reusable claims with primary sources.
+- Identify dominant intent before writing: fix, definition, comparison, tool choice, list, landing page, or mixed intent.
+- Build around intent plus one clear differentiator. Do not copy a competitor structure unless you are improving it.
+- Keep `title`, `description`, `slug`, intro, and first useful section aligned on one promise.
+- Use `serp_title` and `serp_description` only for intentional same-angle overrides, not a second editorial angle.
+- Prefer concrete outcomes, strong query match, and front-loaded payoff over gimmicks. Use dates only when the page is genuinely current.
+- Use the primary keyword naturally in the title, intro, slug, and only 1-2 lower headings.
+- Decide explicitly whether the piece is best for Search, Discover, Google News, or some overlap.
+- `news` posts should prioritize primary-source attribution, visible freshness, and fast usefulness.
+- Refresh internal links on every new or revised post.
+- If the query or angle is visual, assume original visuals are part of the winning plan unless the live SERP says otherwise.
+- Use visuals as indirect SEO support only when they improve clarity, authenticity, or cite-worthiness. Skip decorative filler.
+- For Discover or News targets, the main image should be original when feasible, not a logo, and at least 1200 px wide.
+- Keep related-posts current on non-commercial posts. Commercial posts (`is_commercial: true`) must not include related-posts or read-next blocks.
+- Host all post images on Cloudflare Images.
+- Aim to be cite-worthy for AI and classic search: direct answers, strong subheads, original details, useful examples.
+- No fake freshness, fake authorship, fabricated stats, doorway pages, parasite SEO, expired-domain abuse, link schemes, or scaled thin AI filler.
 
 ## Competitive Reality
 
-- Google’s public guidance matters, but outside data still shows that rankings, backlinks, title decisions, and brand signals affect clicks and AI citations.
-- Use that reality to choose better topics, angles, and titles.
-- Do not turn that into spam tactics. This skill is for durable, defensible SEO on this blog.
+- Public Google guidance matters, but rankings, backlinks, titles, and brand still affect clicks and citations.
+- Use that reality to choose better topics and framing, not spam tactics.
 
-## Workflow
+## Flow
 
 1. If keywords are provided, run the top-3 competitor brief from `references/serp-analysis.md`.
-2. Decide whether the piece should primarily target Search, Discover, Google News, or an overlap of them.
-3. If revising an existing post, compare its current promise, freshness, and gaps against the live SERP before changing structure.
-4. Summarize dominant intent, recurring subtopics, title and snippet patterns, freshness, weak spots, whether the angle has broad feed appeal, and whether the SERP shows meaningful visual intent.
-5. Pick the best angle for us to win on clarity, usefulness, originality, or first-hand value, including a simple decision on whether original screenshots or visuals should be part of the draft.
+2. Decide whether the piece primarily targets Search, Discover, Google News, or an overlap.
+3. If revising an existing post, compare its current promise and freshness against the live SERP first.
+4. Summarize dominant intent, recurring subtopics, title/snippet patterns, freshness, weak spots, and visual intent.
+5. Pick the angle we can win on through clarity, usefulness, originality, or first-hand value, including whether original visuals are needed.
 6. Draft or revise with `post-writing`.
-7. Do a final SEO pass:
-   - title, description, and slug align
-   - `serp_title` and `serp_description` are either `null` or justified, accurate, and aligned with the visible page
-   - title starts strong, uses concrete value, and is not relying on gimmicks for clicks
-   - description leads with the main benefit and still works if Google rewrites part of the snippet
-   - headings match the SERP without sounding repetitive
-   - original visuals were created when the SERP or article angle made them a real advantage, and skipped when they would only add filler
-   - posts aimed at Discover or Google News have a strong lead image that is original when feasible, not a logo, and at least 1200 px wide
-   - news posts are genuinely timely, sourced inline from primary sources, and better suited to a news workflow than an evergreen search page
-   - internal links are relevant, descriptive, and updated for the article's current angle
-   - non-commercial posts have a related-posts list that is present or refreshed, uses a custom article-specific lead-in that does not echo the title, uses contextual anchor text instead of pasted destination titles, and points to genuinely useful next reads without padding
-   - commercial posts do not include a related-posts, read-next, or follow-up reading block
-   - claims are backed by official or primary sources, not just competitors
-   - the page is strong for both classic search and AI search features
+7. Final SEO pass: title/description/slug align, `serp_*` are aligned or `null`, title/snippet lead with concrete value, headings fit intent without stuffing, visuals are added only when useful, Discover/News images are strong, news claims are timely and primary-source-backed, internal links are current, related-posts rules are respected, and claims rely on primary sources rather than competitors.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,65 +1,51 @@
 # benjamincrozat.com
 
-This repo is my personal blog about web development.
+Agent rules for this repo.
 
-## Development workflow
+## Start
 
-- Before starting any task, pull the latest changes from `main` into the active branch or worktree.
-- `composer setup`
-- `composer dev`
-- Serve the project with `php artisan serve` on a non-default port.
-- Commit every change you make, as granularly as practical.
-- Open a PR once the branch is ready to publish, and keep it updated as more changes land.
-- Commit messages should start with a short summary of 10 words or fewer, followed by a detailed list of changes.
+- Sync the active branch/worktree with latest `main` before work.
+- Boot with `composer setup` and `composer dev`.
+- Use `php artisan serve --host=127.0.0.1 --port=<port>` for branch-specific checks.
+- Commit every change; keep commits small.
+- Commit subject: 10 words or fewer, then a detailed list.
+- Open/update the PR when the branch is publishable.
 
 ## Worktrees
 
-- Create feature worktrees from a real branch, not a detached HEAD. Preferred pattern: `git worktree add -b codex/<short-name> <path> main`.
-- If a worktree is detached or behind, switch to a real `codex/...` branch from the latest `origin/main` before making changes.
-- Fresh worktrees may not contain the local runtime files needed to run the app or checks. Reuse the primary checkout's local install by linking these into the new worktree when needed:
-  - `.env` (copy it instead of linking if the worktree needs its own `APP_URL` or other local-only overrides)
-  - `vendor`
-  - `node_modules`
-  - `public/build`
-- The primary local checkout is usually `/Users/benjamin/Sites/blog-v5`. Link missing runtime files from there instead of reinstalling by default.
-- After wiring a fresh worktree, confirm it boots with `php artisan about --only=environment` before running `pint`, `phpstan`, or `pest`.
-- `https://blog-v5.test` may still serve the primary checkout instead of the new worktree. When you need branch-specific browser checks, serve the worktree with `php artisan serve --host=127.0.0.1 --port=<port>` and test against that port.
-- Post image generation uses `BLOG_PREVIEW_BASE_URL` when set, otherwise it falls back to `APP_URL`. For a worktree served through `php artisan serve`, use a worktree-specific `.env` copy and set `APP_URL` to the matching `http://127.0.0.1:<port>` before generating images.
-- Keep worktree-only browser artifacts out of git. Clean up folders like `.playwright-cli/` and `output/` before finishing unless the user explicitly wants those files.
+- Use real branches, not detached HEADs: `git worktree add -b codex/<name> <path> main`.
+- If detached or behind, switch to a fresh `codex/...` branch from `origin/main` before editing.
+- Reuse runtime files from `/Users/benjamin/Sites/blog-v5`: `.env` (copy if local overrides are needed), `vendor`, `node_modules`, `public/build`.
+- After wiring a worktree, run `php artisan about --only=environment` before `pint`, `phpstan`, or `pest`.
+- `https://blog-v5.test` may hit another checkout; use the local `php artisan serve` URL for browser checks.
+- For post image generation in a worktree, set `APP_URL=http://127.0.0.1:<port>` in that worktree's `.env`. `BLOG_PREVIEW_BASE_URL` overrides `APP_URL`.
+- Remove worktree-only artifacts like `.playwright-cli/` and `output/` before finishing unless asked to keep them.
 
-## Guardrails to keep in mind
+## Guardrails
 
-- **Do not overwrite user edits between reads.** If something changed since your last read, understand why and build on it. Ask for clarification only when needed.
-- **Never restore deleted code.** If something was removed, assume it was intentional until you confirm otherwise.
-- **Keep changes small.** Implement the smallest change that solves the problem.
-- **No scope drift.** Do not refactor, restyle, or add “nice-to-haves” unless explicitly requested.
-- **Fix root causes.** Don’t band-aid symptoms.
-- **Use web search when needed.** If version-specific behavior, third-party APIs, or unclear edge cases could change the implementation, verify in official docs/release notes and cite the source in your summary.
-- **State assumptions when needed.** If a requirement is underspecified, proceed with clearly labeled assumptions; only ask questions when blocked.
-- **Be concise and structured.** Prefer short, skimmable answers and concrete next actions over long explanations.
-- **Narrate tool usage briefly.** Before multi-step work or tool calls, give a 1–2 sentence “what I’m doing and why” update.
-- When executing a plan or todo list, continue until it is complete. Don’t ask for permission between tasks.
+- Never overwrite user edits between reads.
+- Never restore deleted code without confirmation.
+- Make the smallest fix that solves the problem.
+- No scope drift: no refactors, restyles, or extras unless asked.
+- Fix root causes, not symptoms.
+- Use web search for unstable or version-specific behavior; cite sources.
+- State assumptions; ask only when blocked.
+- Briefly narrate multi-step tool usage.
+- Finish the full plan once started.
 
-## How to verify your work
+## Verify
 
-- **Use your web browser when the task affects visuals or behavior.**
-  - Set desktop checks to `1512x982`.
-  - Confirm the behavior matches the spec.
-  - Take a screenshot and critique the result for visual quality.
-- If you need credentials to log in, use what's in ./database/seeders/UserSeeder.php. The password is always `password`.
-- **Format**: `php vendor/bin/pint --parallel`
-- **Static analysis**: `php vendor/bin/phpstan analyse`
-- **Test**: `php vendor/bin/pest --parallel` (you can use `--filter` to run specific tests)
-  - **Check coverage**: `php vendor/bin/pest --coverage --parallel` (you can also use `--filter` if necessary too)
-- For routine Markdown-only post edits in `resources/markdown/posts`, use lighter verification by default:
-  - required: `php artisan app:sync-posts`
-  - optional only when warranted: browser checks, `pint`, `phpstan`, `pest`, or coverage
-  - warranted means tricky rendering, embeds, custom HTML, unusual formatting, interactive behavior, a publishing-state change that needs confirmation, first-hand screenshots that materially help the reader, or an explicit user request
+- Visual/behavior changes: use a browser, set desktop to `1512x982`, confirm against spec, take a screenshot, critique the result.
+- Login seed: `database/seeders/UserSeeder.php`, password `password`.
+- Format: `php vendor/bin/pint --parallel`
+- Static analysis: `php vendor/bin/phpstan analyse`
+- Tests: `php vendor/bin/pest --parallel`
+- Coverage when needed: `php vendor/bin/pest --coverage --parallel`
+- Routine Markdown-only edits in `resources/markdown/posts`: run `php artisan app:sync-posts`. Add browser checks, `pint`, `phpstan`, `pest`, or coverage only for tricky rendering, embeds, custom HTML, unusual formatting, interactive behavior, publishing-state checks, useful first-hand screenshots, or explicit requests.
 
 ## Local skills
 
-- For Markdown-managed post work, follow the lighter verification rule above so these skills stay aligned with this file.
-- `file-first-posts`: Export, edit, publish, or sync Markdown-managed posts. File: `.agents/skills/file-first-posts/SKILL.md`
-- `framework-news-analysis`: Choose and frame the strongest weekly news angle for a framework, library, tool, platform, or developer product. File: `.agents/skills/framework-news-analysis/SKILL.md`
-- `post-writing`: Draft or revise publication-ready Markdown posts for the blog. File: `.agents/skills/post-writing/SKILL.md`
-- `seo-content`: Handle search intent, titles, snippets, internal links, AI-search visibility, and top-3 competitor analysis for blog posts and keywords. File: `.agents/skills/seo-content/SKILL.md`
+- `file-first-posts`: Markdown post export/edit/publish/sync. File: `.agents/skills/file-first-posts/SKILL.md`
+- `framework-news-analysis`: Weekly framework/tool news angle and sourcing. File: `.agents/skills/framework-news-analysis/SKILL.md`
+- `post-writing`: Publication-ready blog drafting/revision. File: `.agents/skills/post-writing/SKILL.md`
+- `seo-content`: Search, Discover, News, and competitor framing. File: `.agents/skills/seo-content/SKILL.md`


### PR DESCRIPTION
## Summary
- tighten `AGENTS.md` and the local agent skills so they stay concise and task-focused
- remove repeated guidance while keeping the required commands and publishing rules
- add a README section that requires agents to use worktrees by default and to push worktree branches and open a PR

## Testing
- git diff --check