### PR TITLE
Refresh PHP array_map guide

### DIFF
--- a/resources/markdown/posts/php-array-map.md
+++ b/resources/markdown/posts/php-array-map.md
@@ -7,20 +7,23 @@ description: "Use PHP array_map() to transform arrays, map multiple arrays at on
 categories:
   - "php"
 published_at: 2023-11-04T00:00:00+01:00
-modified_at: 2026-03-14T10:09:06Z
+modified_at: 2026-03-19T09:35:00+00:00
 serp_title: null
 serp_description: null
 canonical_url: ""
 is_commercial: false
 image_disk: "cloudflare-images"
-image_path: "images/posts/4kTmON58dztZanh.jpg"
+image_path: "images/posts/generated/php-array-map.png"
 sponsored_at: null
 ---
 ## Introduction
 
 **Use [`array_map()`](https://www.php.net/array_map) when you want to transform every item in an array and return a new array.**
 
-It is a clean alternative to building a second array manually in a `foreach` loop, and it becomes even more useful when you need to map multiple arrays at once. The main rule worth remembering is that keys are preserved only when you pass one array.
+It is a clean alternative to building a second array manually in a `foreach` loop, and it becomes even more useful when you need to map multiple arrays at once. The two rules worth remembering are:
+
+- keys are preserved only when you pass one array
+- `array_map()` passes values, not keys, unless you deliberately pass keys as another array
 
 ## How to use array_map() in PHP
 
@@ -35,36 +38,32 @@ The callback receives the current value from each array position and returns the
 Here is a simple example:
 
 ```php
-function discount(float $price): float
-{
-    return $price * 0.8;
-}
-
-$prices = [10, 20, 30, 40, 50];
-
-$discountedPrices = array_map('discount', $prices);
+$frameworks = ['laravel', 'symfony', 'livewire'];
+$upper = array_map('strtoupper', $frameworks);
 ```
 
-`$discountedPrices` contains:
+`$upper` contains:
 
 ```php
 [
-    8.0,
-    16.0,
-    24.0,
-    32.0,
-    40.0,
+    'LARAVEL',
+    'SYMFONY',
+    'LIVEWIRE',
 ]
 ```
 
-Closures and arrow functions work just as well:
+Arrow functions work just as well:
 
 ```php
+$prices = [10, 20, 30];
+
 $discountedPrices = array_map(
     fn (float $price): float => $price * 0.8,
-    $prices,
+    $prices
 );
 ```
+
+That “transform every item into another item” use case is where `array_map()` shines.
 
 ## Mapping multiple arrays at once
 
@@ -86,6 +85,19 @@ $discountedProducts = array_map(
 
 This builds a new array from the matching positions of `$products` and `$prices`.
 
+If the arrays are not the same length, PHP keeps going and fills missing values with `null`:
+
+```php
+$letters = ['a', 'b'];
+$numbers = [1, 2, 3];
+
+array_map(null, $letters, $numbers);
+
+// [['a', 1], ['b', 2], [null, 3]]
+```
+
+That matters when you assume the arrays are perfectly aligned.
+
 ## array_map() and array keys
 
 One subtle rule from the PHP manual is worth remembering:
@@ -106,6 +118,27 @@ $upper = array_map('strtoupper', $users);
 ```
 
 But the earlier multi-array example returns `0`, `1`, `2`, and so on.
+
+## How to map keys too
+
+`array_map()` does not pass array keys to the callback on its own. If you need both the key and the value, pass them explicitly:
+
+```php
+$users = [
+    'first' => 'Ben',
+    'second' => 'Taylor',
+];
+
+$labels = array_map(
+    fn (string $value, string $key): string => strtoupper($key) . ':' . $value,
+    array_values($users),
+    array_keys($users),
+);
+
+// ['FIRST:Ben', 'SECOND:Taylor']
+```
+
+That is a good pattern when you want key-aware transformations without falling back to `foreach`.
 
 ## Passing null as the callback
 


### PR DESCRIPTION
## Summary
- move the most useful transformation examples higher in the article
- add clearer guidance around key preservation, key-aware mapping, and uneven arrays
- regenerate the post image and sync the posts database

## Verification
- `php -r ...` checks for key preservation, reindexing, null fill, and key-aware mapping
- `php artisan app:generate-post-image php-array-map --force`
- `curl http://127.0.0.1:8123/php-array-map`
- `curl -I http://127.0.0.1:8123/preview/posts/php-array-map/image`
