### PR TITLE
Refresh next five SEO articles

### DIFF
--- a/resources/markdown/posts/bun-package-manager.md
+++ b/resources/markdown/posts/bun-package-manager.md
@@ -1,13 +1,13 @@
 ---
 id: "01KKEW277JF4527Q2P4FY99H1S"
-title: "Bun vs pnpm, npm, and Yarn for package management"
+title: "Bun vs pnpm vs npm: when Bun is worth it"
 slug: "bun-package-manager"
 author: "benjamincrozat"
-description: "Compare Bun with pnpm, npm, and Yarn for installs, lockfiles, monorepos, and security defaults before you switch package managers."
+description: "Compare Bun with pnpm and npm for lockfiles, workspaces, dependency scripts, and migration risk before you switch package managers."
 categories:
   - "javascript"
 published_at: 2023-09-11T00:00:00+02:00
-modified_at: 2026-03-13T15:40:00Z
+modified_at: 2026-03-19T22:39:10Z
 serp_title: null
 serp_description: null
 canonical_url: null
@@ -16,233 +16,168 @@ image_disk: "cloudflare-images"
 image_path: "images/posts/KXZTmSmiqR38COC.jpg"
 sponsored_at: null
 ---
-## Bun vs pnpm, npm, and Yarn
+## Introduction
 
-**If you are comparing Bun to pnpm, npm, or Yarn, the first thing to know is that Bun is more than a package manager.**
+**If your real question is "should I switch to Bun?", the short answer is this: choose Bun when you want an all-in-one toolchain, not just a different package manager.**
 
-[Bun](https://bun.sh) is also a runtime, test runner, and bundler, with an npm-compatible package manager built in.
+If you only want the package-manager decision fast:
 
-That makes the comparison slightly uneven:
+- choose **Bun** when you want installs, scripts, and the runtime to move together
+- choose **pnpm** when you want the strongest package-manager upgrade with minimal runtime disruption
+- choose **npm** when compatibility and lowest-friction defaults matter more than changing tools
 
-- compare **Bun vs pnpm** when you care most about installs, lockfiles, and monorepos
-- compare **Bun vs npm** when you want a more modern default than the standard Node.js toolchain
-- compare **Bun vs Yarn** when you are moving off an older workflow and want fewer moving pieces
+That framing matters because Bun is not only a package manager. It is also a runtime, test runner, and bundler.
 
-## When Bun is a good fit
+## The core decision: Bun vs pnpm vs npm
 
-Bun makes sense when you want:
+Here is the quickest way to compare them for real-world use.
 
-- one tool for runtime, scripts, tests, and package management
-- automatic migration from `package-lock.json`, `yarn.lock`, or `pnpm-lock.yaml`
-- a text-based `bun.lock`
-- monorepo filtering with `bun install --filter`
-- stricter dependency-script defaults through `trustedDependencies`
+| Tool | Best fit | Runtime included | Lockfile | Monorepo workflow | Script security default |
+| --- | --- | --- | --- | --- | --- |
+| Bun | You want one fast tool for install + run + build + test | Yes | `bun.lock` | Good, with `--filter` and isolated installs | Dependency scripts are not run by default |
+| pnpm | You want the strongest package-manager upgrade while staying in standard Node.js land | No | `pnpm-lock.yaml` | Excellent | Traditional Node ecosystem behavior |
+| npm | You want the safest compatibility baseline | No | `package-lock.json` | Fine, but less opinionated | Traditional Node ecosystem behavior |
 
-If you only want a package manager and are otherwise happy with your current Node.js setup, pnpm is usually the closer comparison.
+If you read nothing else, that table captures the real tradeoff better than vague "Bun is fast" claims.
 
-## What Bun's package manager does today
+## When Bun is worth switching to
 
-Bun's package manager can:
+Bun is a good fit when at least one of these is true:
 
-- install dependencies with `bun install`
-- add and remove packages with `bun add` and `bun remove`
-- migrate existing npm, Yarn, and pnpm lockfiles
-- use filtered installs in monorepos
-- use isolated installs for new workspaces and monorepos
-- skip dependency lifecycle scripts unless you explicitly trust them
+- you want to replace both your package manager and runtime together
+- you want one command style across install, scripts, tests, and builds
+- you are starting a fresh project and do not need maximum historical compatibility
+- your team wants stricter dependency-script behavior by default
 
-## Install Bun
+Bun is a weaker fit when your main goal is only "make installs better" while keeping everything else exactly the same. In that case, pnpm is usually the more conservative choice.
 
-### macOS
+## Bun vs pnpm
 
-- Homebrew (preferred):
-```bash
-brew install oven-sh/bun/bun
-```
-- Or with the official installer:
-```bash
-curl -fsSL https://bun.com/install | bash
-```
-See the current [installation guide](https://bun.sh/docs/installation) for details.
+This is usually the comparison that matters most.
 
-### Linux and WSL
+### Choose Bun over pnpm when:
 
-Use the official installer:
+- you want Bun's runtime as part of the switch
+- you like Bun's text lockfile and integrated tooling story
+- you want a package manager that can also run your scripts without adding another layer
 
-```bash
-curl -fsSL https://bun.com/install | bash
-```
+### Choose pnpm over Bun when:
 
-If needed, install `unzip` first:
+- you want the smallest possible change from a standard Node.js stack
+- you care most about package-manager behavior, not runtime consolidation
+- you have a mature monorepo and prefer the most established workspace story
 
-```bash
-sudo apt install unzip
-```
+Bun's isolated installs are explicitly positioned as similar to pnpm's stricter dependency model, which is useful if you want pnpm-like discipline without adopting pnpm itself.
 
-Kernel 5.6+ is recommended (5.1 minimum). See the [installation guide](https://bun.sh/docs/installation).
+## Bun vs npm
 
-### Windows
+This comparison is simpler.
 
-Bun is fully supported on Windows 10 version 1809 and later. Install from PowerShell:
+### Choose Bun over npm when:
 
-```powershell
-powershell -c "irm bun.sh/install.ps1 | iex"
-```
+- you want a more modern toolchain default
+- you are open to adopting a different runtime
+- you want workspace filtering and Bun-native tooling in one place
 
-Full support arrived with Bun 1.1 and covers the runtime, test runner, package manager, and bundler. See the [Bun 1.1 Windows announcement](https://bun.sh/blog/bun-v1.1) and the [installation guide](https://bun.sh/docs/installation).
+### Keep npm when:
 
-## Migrating from npm, Yarn, or pnpm
+- maximum compatibility matters more than tool consolidation
+- the project already works well and the switch would create churn without meaningful payoff
+- your team is not trying to change runtimes right now
 
-As of Bun v1.2, the default lockfile is the text-based `bun.lock`. If a repo still has `bun.lockb`, migrate like this:
+In other words, Bun is not an "npm but a bit nicer" choice. It is a broader stack decision.
 
-```bash
-bun install --save-text-lockfile
-# commit bun.lock, then remove the binary lockfile
-rm bun.lockb
-```
+## The Bun package-manager features that matter most
 
-When `bun install` runs in a project without `bun.lock`, Bun can automatically migrate these lockfiles:
+The current Bun docs make these details worth paying attention to:
 
-- `package-lock.json`
-- `yarn.lock`
-- `pnpm-lock.yaml`
+- Bun now uses the text-based `bun.lock` lockfile
+- `bun install --save-text-lockfile` helps migrate older binary lockfiles
+- `bun install --frozen-lockfile` is the no-surprises install mode for CI-style workflows
+- `bun install --filter` targets specific workspace packages
+- Bun supports isolated installs with `--linker isolated`
+- dependency scripts are not run by default, and trusted packages can be allow-listed
 
-The original lockfile is preserved, so you can verify the install before deleting the old file.
+Those are meaningful differences, not cosmetic ones.
 
-## bun install, bun add, and bun remove
+## A practical migration path
 
-Install dependencies:
+If you are testing Bun in an existing npm, Yarn, or pnpm project, keep the migration boring:
 
 ```bash
 bun install
 ```
 
-Helpful flags for installs:
-- `--no-cache`: ignores the manifest cache during resolution.
-- `--frozen-lockfile`: installs exactly what `bun.lock` says.
-- `--production` and `--omit`: control which dependency types are installed.
-- `--filter`: target specific workspace packages in a monorepo.
-See the [bun install docs](https://bun.com/docs/cli/install).
+Bun can migrate these lockfiles automatically when `bun.lock` does not exist:
 
-![Terminal screenshot of bun install with successful dependency install.](https://imagedelivery.net/hYERsDhHaFG137wdGnWeuA/images/posts/imported/bun-laravel-5b693360c03cdefebee1.jpg/public)
+- `package-lock.json`
+- `yarn.lock`
+- `pnpm-lock.yaml`
 
-Add dependencies:
+If you are moving from the older binary lockfile format, convert it like this:
 
 ```bash
-bun add tailwindcss autoprefixer postcss
-# dev dependencies
-bun add -d typescript vitest
-# pin exact versions
-bun add --exact react
+bun install --save-text-lockfile
+rm bun.lockb
 ```
 
-See the [bun add docs](https://bun.sh/docs/cli/add).
+That gives you a reviewable text lockfile before you fully commit to the switch.
 
-![Terminal screenshot of bun add installing tailwindcss, autoprefixer, and postcss.](https://imagedelivery.net/hYERsDhHaFG137wdGnWeuA/images/posts/imported/bun-laravel-c58deeed47edc94b9356.jpg/public)
+## Monorepos and workspace filtering
 
-Remove a dependency:
+Bun has become much more credible for monorepo workflows than the early versions many people still remember.
 
-```bash
-bun remove axios
-```
-
-More flags and behavior are in the [install and remove docs](https://bun.com/docs/cli/install).
-
-Run scripts from package.json with Bun:
-
-```bash
-bun run dev
-```
-
-See the [run command docs](https://bun.com/docs/cli/run).
-
-## Keeping dependencies current: bun outdated and bun update
-
-Check for updates:
-
-```bash
-bun outdated
-```
-
-Update everything or a single package:
-
-```bash
-bun update
-bun update react
-```
-
-Review changes interactively:
-
-```bash
-bun update --interactive
-```
-
-See the [update and outdated docs](https://bun.com/docs/cli/update).
-
-## Workspaces and monorepos
-
-Bun supports workspaces and two linker strategies: `isolated` and `hoisted`.
-
-For fresh workspaces and monorepos, Bun now defaults to `isolated`, which helps prevent phantom dependencies. For new single-package projects, the default is `hoisted`.
-
-Example workspace root:
-
-```json
-{
-  "name": "acme",
-  "private": true,
-  "workspaces": ["apps/*", "packages/*"]
-}
-```
-
-Use an isolated layout explicitly:
-
-```bash
-bun install --linker isolated
-```
-
-Target specific packages in large repos:
+Useful commands include:
 
 ```bash
 bun install --filter apps/web --filter packages/ui
 ```
 
-See workspace flags in the [install docs](https://bun.com/docs/cli/install).
-
-## Security defaults and CI
-
-Bun does not run dependency lifecycle scripts by default. If certain scripts are trusted, allow-list them with `trustedDependencies` in `package.json`:
-
-```json
-{
-  "trustedDependencies": ["esbuild", "node-gyp"]
-}
-```
-
-For CI, use:
+And if you want stricter dependency boundaries:
 
 ```bash
-bun ci
+bun install --linker isolated
 ```
 
-That is equivalent to `bun install --frozen-lockfile`.
+That is the part of Bun that overlaps most with pnpm's appeal.
 
-## So, should you pick Bun or pnpm?
+## Security and dependency scripts
 
-If your real comparison is **Bun vs pnpm**, I would simplify it like this:
+One reason some teams like Bun is that dependency scripts are not run by default.
 
-- choose **Bun** when you want a faster-moving all-in-one toolchain and are happy to adopt its runtime and package-manager model together
-- choose **pnpm** when you mainly want a package manager and want the smallest change to an otherwise standard Node.js setup
-- keep **npm** when compatibility and lowest-friction defaults matter more than changing tools
-- keep **Yarn** mostly when your existing project already depends on Yarn-specific behavior
+If you trust specific packages, you can explicitly allow them with `trustedDependencies` in `package.json`.
+
+That makes Bun's default posture more appealing for cautious teams than the classic "install first, hope the lifecycle scripts are fine" flow.
+
+## So, when should you actually switch?
+
+Here is the decision framework I would use.
+
+### Switch to Bun now if:
+
+- you want Bun as both runtime and package manager
+- you are starting a new app or modernizing a simpler project
+- you want one tool to cover install, run, and test workflows
+
+### Prefer pnpm if:
+
+- your project already runs on Node.js and you want the least disruptive improvement
+- the main pain is package management, not runtime choice
+- you have a large monorepo and want the most mature package-manager-first path
+
+### Stay on npm if:
+
+- your team values stability over experimentation
+- the current setup is not the bottleneck
+- third-party tooling compatibility is the main priority
 
 ## Conclusion
 
-Bun is strongest when you want one tool to cover package management, script execution, and the runtime itself. If your decision is mostly about monorepo installs and lockfiles, pnpm is still the comparison to think through most carefully. If your goal is a simpler modern default with fewer moving pieces, Bun is worth serious consideration.
+Bun is worth switching to when you want a broader tooling change, not just a faster install command. If you mostly want a better package manager while keeping the rest of your Node.js setup familiar, pnpm is usually the sharper comparison and often the safer answer.
 
-If you are deciding whether Bun should replace your current package-manager habit, these are the next reads I would compare alongside it:
+If you are comparing Bun against the rest of your JavaScript workflow, these are the next reads I would keep open:
 
-- [Use Bun in plain PHP projects too, not just Laravel](/bun-php)
 - [Swap npm out for Bun in Laravel without friction](/bun-laravel)
-- [Use npm ci when you need repeatable installs, not surprises](/npm-ci)
+- [Use Bun in plain PHP projects too, not just Laravel](/bun-php)
+- [Use `npm ci` when you need repeatable installs, not surprises](/npm-ci)
 - [Hide the npm funding message when you just want clean installs](/npm-fund)

--- a/resources/markdown/posts/check-php-version.md
+++ b/resources/markdown/posts/check-php-version.md
@@ -1,14 +1,14 @@
 ---
 id: "01KKEW2780NK2M3H3CFCG87HN6"
-title: "Check PHP version: command line and browser methods"
+title: "How to check your PHP version quickly"
 slug: "check-php-version"
 author: "benjamincrozat"
-description: "Check your PHP version with php -v, phpinfo(), phpversion(), or Laravel's php artisan about command, and know which method fits CLI or browser access."
+description: "Check your PHP version with php -v, phpversion(), phpinfo(), or Laravel's artisan about command, depending on whether you are in CLI, browser, or a Laravel app."
 categories:
   - "laravel"
   - "php"
 published_at: 2023-09-02T00:00:00+02:00
-modified_at: 2026-03-14T10:17:05Z
+modified_at: 2026-03-19T22:39:10Z
 serp_title: null
 serp_description: null
 canonical_url: ""
@@ -19,92 +19,158 @@ sponsored_at: null
 ---
 ## Introduction
 
-**To check your [PHP](https://www.php.net) version, run `php -v` in your terminal.** The first line shows your current version immediately.
+**To check your PHP version, run `php -v` in your terminal.**
 
-If you cannot use the terminal, `phpinfo()`, `phpversion()`, and Laravel's `php artisan about` command are the next easiest options.
+That is the fastest and most reliable method when you have shell access.
 
-## Run `php -v` in your terminal
+If you do not have terminal access, use one of these instead:
 
-This method works perfectly on macOS, Linux, Windows, and WSL.
+- `phpversion()` for a tiny browser-safe output
+- `phpinfo()` if you need full configuration details
+- `php artisan about` inside a Laravel project
+
+## Check PHP version in the CLI
+
+For most people, this is the right answer.
 
 ```bash
 php -v
 ```
 
-This outputs something like `PHP 8.4.4 (cli) (built: ...)`.
+You will get output like this:
 
-## Use the `phpversion()` function
-
-![Checking PHP version using phpversion().](https://imagedelivery.net/hYERsDhHaFG137wdGnWeuA/images/posts/imported/check-php-version-068c21630df8ec212ffd.jpg/public)
-
-Simply create a PHP script containing:
-
-```php
-<?php echo phpversion(); ?>
-// Output: 8.4.4
+```text
+PHP 8.4.16 (cli) ...
 ```
 
-## Use the `phpinfo()` function
+That first line is enough if you only want the current version.
 
-![Checking PHP version using phpinfo().](https://imagedelivery.net/hYERsDhHaFG137wdGnWeuA/images/posts/imported/check-php-version-b4f57c73364e57eadefb.jpg/public)
+### Why `php -v` is usually the best method
 
-Create a PHP file with:
+- it is fast
+- it works on macOS, Linux, Windows, and WSL
+- it tells you which PHP binary your shell is actually using
+
+If you have multiple PHP versions installed, the terminal result may not match the version your web server is using. That is where the browser methods below help.
+
+## Check PHP version in the browser
+
+If you need to know what the web server is running, use `phpversion()` or `phpinfo()`.
+
+### Use `phpversion()` for the cleanest output
+
+Create a temporary PHP file with:
 
 ```php
-<?php phpinfo(); ?>
+<?php
+
+echo phpversion();
 ```
 
-Open this in your browser and find the PHP version at the top.
+That prints only the version string, which makes it the cleaner browser option when you do not need extra details.
 
-## Check PHP version using Laravel's welcome page
+The PHP manual describes `phpversion()` as the function that gets the current PHP version.
 
-![Laravel welcome page showing PHP version.](https://imagedelivery.net/hYERsDhHaFG137wdGnWeuA/images/posts/imported/check-php-version-061c7222686bd6a5e33c.jpg/public)
+### Use `phpinfo()` when you also need configuration details
 
-Laravel conveniently shows your PHP version in the bottom-right corner of the default welcome page.
+Create a file like this:
 
-## Check PHP version with Laravel Artisan
+```php
+<?php
 
-![Checking PHP version using Laravel Artisan.](https://imagedelivery.net/hYERsDhHaFG137wdGnWeuA/images/posts/imported/check-php-version-c2831ffe38082032d779.jpg/public)
+phpinfo();
+```
 
-From your Laravel project's root, run:
+Open it in your browser and look at the top of the page.
+
+This is useful when you need more than the version number, for example:
+
+- loaded extensions
+- active `php.ini`
+- SAPI details
+- environment information
+
+The tradeoff is that `phpinfo()` exposes a lot more information, so do not leave that file publicly accessible after you are done.
+
+## Check PHP version in Laravel
+
+If you are already inside a Laravel project, this is the easiest framework-aware command:
 
 ```bash
 php artisan about
 ```
 
-You'll see your PHP version along with other useful details.
-If you also need the framework version, here are [6 ways to check Laravel's version](/check-laravel-version).
+You will see the PHP version alongside your Laravel version and other environment details.
+
+If you want the framework version too, here is the companion guide:
+
+[Ways to check which Laravel version you are running](/check-laravel-version)
+
+## Why the browser and CLI versions sometimes differ
+
+This confusion is extremely common.
+
+Your terminal may use one PHP binary while Apache, nginx, PHP-FPM, Valet, or Herd uses another.
+
+If that happens:
+
+1. run `php -v` in the terminal
+2. check the browser version with `phpversion()` or `phpinfo()`
+3. compare the results
+
+If they are different, you are looking at two different PHP runtimes.
+
+That is usually a configuration issue, not a PHP bug.
+
+## Which method should you use?
+
+Use this simple rule:
+
+| Situation | Best method |
+| --- | --- |
+| You have terminal access | `php -v` |
+| You need the web-server version | `phpversion()` |
+| You need config details too | `phpinfo()` |
+| You are already in a Laravel app | `php artisan about` |
 
 ## FAQ
 
 ### How do I check my PHP version on macOS?
 
-Run `php -v` in your macOS terminal.
+Run:
 
-### How do I check my PHP version on Ubuntu?
+```bash
+php -v
+```
 
-Run `php -v` in your Ubuntu terminal.
+### How do I check my PHP version on Ubuntu or Debian?
+
+Run:
+
+```bash
+php -v
+```
 
 ### How do I check my PHP version on Windows?
 
-Run `php -v` in your Windows command prompt.
+Run the same command in Command Prompt, PowerShell, or Windows Terminal:
 
-### Which PHP versions are end-of-life (EOL) in 2026?
+```powershell
+php -v
+```
 
-PHP 7.x and older are long end-of-life, and even older PHP 8 branches may already be out of active support depending on the exact minor version. Check the official [supported versions page](https://www.php.net/supported-versions.php) before you plan an upgrade path.
+### How do I check the PHP version used by my website?
 
-### How do I find my PHP version in WordPress?
+Use a temporary file with `phpversion()` or `phpinfo()` and open it in the browser. That shows the PHP runtime behind the web server, not just the one in your shell.
 
-In the admin panel, go to **Tools → Site Health → Info → Server**.
+### Which PHP versions are still supported in 2026?
 
-### Can I have multiple PHP versions installed?
+Check the official [PHP supported versions page](https://www.php.net/supported-versions.php) before planning an upgrade. As of March 19, 2026, PHP **8.5** and **8.4** are in active support, while older branches are further along in their lifecycle.
 
-Yes! Tools like [Laravel Herd](/laravel-herd), [Laravel Valet](/laravel-valet), [Homebrew](https://brew.sh) (macOS), [Docker](https://www.docker.com), and version managers allow multiple PHP versions on the same system.
+If you know your PHP version now and need the next step, these are the follow-up reads I would open:
 
-Once you know which PHP version you are really on, these next reads help with local setup, config, and the Laravel side around it:
-
-- [Run PHP and Laravel more smoothly on macOS](/laravel-valet)
+- [Find the `php.ini` file that is actually affecting your setup](/php-ini-location)
+- [Check which Laravel version is running too](/check-laravel-version)
 - [Set up PHP on macOS or Windows with less friction](/laravel-herd)
-- [Find the php.ini file that's actually affecting your setup](/php-ini-location)
-- [Double-check which Laravel version is actually running](/check-laravel-version)
+- [Run PHP and Laravel more smoothly on macOS](/laravel-valet)
 - [Set up Laravel on macOS without a messy local stack](/laravel-installation-macos)

--- a/resources/markdown/posts/laravel-herd.md
+++ b/resources/markdown/posts/laravel-herd.md
@@ -94,7 +94,7 @@ That makes it a much simpler starting point than piecing together a Homebrew-bas
 
 ## PHP versions in Laravel Herd
 
-Herd now ships with the latest stable PHP version by default. As of March 19, 2026, the official macOS and Windows docs say that default is PHP 8.5.
+Herd ships with the latest stable PHP version by default, and its current public pages show support from PHP 7.4 through PHP 8.5.
 
 You can change the global PHP version from the app or with the CLI:
 

--- a/resources/markdown/posts/laravel-herd.md
+++ b/resources/markdown/posts/laravel-herd.md
@@ -3,12 +3,12 @@ id: "01KKEW27CG49GRV02BM10BPV0S"
 title: "How to install Laravel Herd on macOS and Windows"
 slug: "laravel-herd"
 author: "benjamincrozat"
-description: "Download and install Laravel Herd on macOS or Windows to get PHP, nginx, and Node.js running quickly for local development."
+description: "Install Laravel Herd on macOS or Windows to get PHP, nginx, Composer, Node.js, and .test sites running with less local setup friction."
 categories:
   - "laravel"
   - "tools"
 published_at: 2023-07-19T00:00:00+02:00
-modified_at: 2026-03-13T12:20:00Z
+modified_at: 2026-03-19T22:39:10Z
 serp_title: null
 serp_description: null
 canonical_url: null
@@ -19,27 +19,50 @@ sponsored_at: null
 ---
 ## Introduction
 
-[Laravel Herd](https://herd.laravel.com) is a free app for local PHP development on macOS and Windows.
+**Laravel Herd is the easiest local PHP stack for macOS or Windows if you want PHP, nginx, Composer, Node.js, and `.test` domains without stitching everything together by hand.**
 
-You can download Herd, install it in a few minutes, and get PHP, nginx, and Node.js ready for local Laravel work without a Homebrew-heavy setup. If you prefer that workflow, I also wrote about [Laravel Valet](https://benjamincrozat.com/install-php-mac-laravel-valet).
+If you only need the short version:
+
+- install **Herd** on **macOS 12+** or **Windows 10+**
+- open it once and finish the onboarding flow
+- verify with `herd --version`, `php --version`, and `composer --version`
+- use `herd isolate` when a project needs a different PHP version
+
+The official docs now position Herd as the dependency-light alternative to a Homebrew-heavy or manually assembled local stack.
+
+## What Laravel Herd gives you
+
+After setup, Herd gives you a local environment with:
+
+- PHP
+- nginx
+- Composer
+- the Laravel installer
+- Node.js
+- `.test` local domains
+
+That is why Herd is attractive for Laravel work: it gets you from "new machine" to "app running locally" faster than a more manual stack.
 
 ## Install Laravel Herd on macOS
 
 ### Requirements
 
-- macOS 12 or later
+According to the official macOS installation docs, Herd requires **macOS 12.0 or later**.
 
-### Steps
+### Installation steps
 
-1. [Download Herd](https://herd.laravel.com/download) from the official site.
-2. Open the disk image and drag the app to your Applications folder.
-3. Launch Herd and follow the setup. You can start fresh or import your [Laravel Valet](https://benjamincrozat.com/install-php-mac-laravel-valet) sites.
+1. Download the latest macOS build from [the official Herd download page](https://herd.laravel.com/download).
+2. Open the DMG file.
+3. Drag Herd into the **Applications** folder.
+4. Launch Herd to start the onboarding process.
 
-Herd includes nvm, so it can install and switch Node.js versions for you.
+During onboarding, Herd downloads the latest PHP version and installs its background service for nginx and local DNS handling.
 
-### Verify your setup
+If you are moving from Valet, Herd can detect an existing Valet installation and migrate sites, certificates, and settings.
 
-Run these commands in Terminal:
+### Verify the install
+
+Run:
 
 ```bash
 herd --version
@@ -49,21 +72,25 @@ composer --version
 node --version
 ```
 
+If those commands resolve, the core setup is working.
+
 ## Install Laravel Herd on Windows
 
 ### Requirements
 
-- Windows 10 or later
+The current Windows installation docs say Herd requires **Windows 10 or higher** and needs **administrator privileges** during setup.
 
-### Steps
+### Installation steps
 
-1. [Download Herd for Windows](https://herd.laravel.com/windows/).
-2. Run the installer, then open Herd and follow the prompts.
-3. For details, see the [Herd for Windows install docs](https://herd.laravel.com/docs/windows).
+1. Download Herd from [the official Windows download page](https://herd.laravel.com/download/windows).
+2. Run the installer as an administrator.
+3. Open Herd and complete the setup flow.
 
-### Verify your setup
+The Windows installer adds the Herd helper service that handles host-file updates and maps local sites to `.test` domains.
 
-Run these commands in PowerShell:
+### Verify the install
+
+Run these in PowerShell or Windows Terminal:
 
 ```powershell
 herd --version
@@ -73,159 +100,103 @@ composer --version
 node --version
 ```
 
-## Supported PHP versions
+## Which PHP version does Herd install?
 
-Herd supports PHP 7.4, 8.0, 8.1, 8.2, 8.3, and 8.4. New installs default to PHP 8.4 since January 10, 2025. See the [supported PHP versions](https://herd.laravel.com/docs/1/technology/php-versions) and the macOS [updates page](https://herd.mintlify.dev/docs/macos/getting-started/updates) for details.
+Herd now ships with the **latest stable PHP version by default**.
 
-## Included PHP extensions
+As of **March 19, 2026**, the Herd docs say that default is **PHP 8.5** on both macOS and Windows.
 
-Herd includes many extensions out of the box, including:
+That is a meaningful update from older Herd guides that were anchored to PHP 8.4.
 
-- bcmath
-- bz2
-- calendar
-- ctype
-- curl
-- dba
-- dom
-- exif
-- ffi
-- fileinfo
-- filter
-- ftp
-- gd
-- gmp
-- iconv
-- igbinary
-- imagick
-- imap
-- intl
-- ldap
-- lz4
-- mbstring
-- mongodb
-- mysqli
-- opcache
-- openssl
-- pcntl
-- pdo
-- pdo_mysql
-- pdo_pgsql
-- pdo_sqlite
-- pdo_sqlsrv
-- pgsql
-- phar
-- posix
-- readline
-- redis
-- session
-- shmop
-- simplexml
-- soap
-- sockets
-- sodium
-- sqlite3
-- sqlsrv
-- sysvmsg
-- sysvsem
-- sysvshm
-- tokenizer
-- xml
-- xmlreader
-- xmlwriter
-- xsl
-- zip
-- zlib
+## Switching PHP versions globally or per project
 
-Availability can vary by OS. For the full, always‑current list, see the official page on [included PHP extensions](https://herd.laravel.com/docs/1/technology/php-extensions).
+This is one of Herd's best features.
 
-### How to add extensions
-
-Although Herd includes many extensions, you can add more.
-
-- On macOS: use Homebrew or PECL, then enable the extension and restart Herd. For example:
+You can switch the global PHP version:
 
 ```bash
-pecl install xdebug
-# then enable it in your php.ini if needed
-herd restart
+herd use 8.5
 ```
 
-- On Windows: download the matching DLL for your PHP version, place it in the ext folder, enable it in php.ini (for example, `extension=php_intl.dll`), then restart Herd.
-
-See the step‑by‑step guide in the [PHP extensions docs](https://herd.laravel.com/docs/1/technology/php-extensions).
-
-## The strengths of Laravel Herd compared to Valet
-
-- Everything you need is bundled. I thought Valet was simple, but Herd is even simpler for a quick start.
-- No Homebrew or Docker required for the core setup.
-- The team says your tests and web requests run faster with Herd. See the claim on the [Herd site](https://herd.laravel.com).
-
-## The limitations of Laravel Herd compared to Valet
-
-Using Herd, you may hit these limits:
-
-- You cannot install PHP versions before 7.4.
-- Herd does not include every extension by default, but you can add more. See How to add extensions above.
-
-## Herd Pro: features and pricing
-
-Herd Basic is free. Herd Pro costs $99 for a one‑year license, and you can activate it on two devices. A teams option is available. Learn more on the [Herd Pro page](https://herd.laravel.com).
-
-Herd Pro adds:
-
-- Mail viewer
-- Dumps inspector
-- Log viewer
-- Services: MySQL, MariaDB, PostgreSQL, Redis, Typesense, Meilisearch, MinIO, Laravel Reverb
-- Xdebug detection and helpers
-
-## Switch PHP versions per project
-
-Use Herd to switch globally or per project:
+Or isolate a single project to its own PHP version:
 
 ```bash
-# set the global default
-herd use 8.4
-
-# in a project folder, pin a version
 cd ~/Sites/my-app
-herd isolate 8.1
+herd isolate 8.3
+```
 
-# remove the pin
+Remove that per-project pin with:
+
+```bash
 herd unisolate
 ```
 
-See the full guide on [managing PHP versions](https://herd.laravel.com/docs/1/technology/php-versions).
+If you work across older and newer Laravel apps, this is where Herd becomes more useful than a one-version local stack.
+
+## Managing extra PHP versions
+
+The current Herd docs focus less on a fixed support matrix and more on managing PHP versions through the app or CLI.
+
+The practical takeaway is:
+
+- Herd installs the latest stable PHP version by default
+- you can install additional versions as needed
+- you can set a global version or isolate a single project
+
+That is a better mental model than memorizing an older static list of bundled versions.
+
+## PHP extensions in Herd
+
+Herd includes many extensions out of the box, but not every possible one.
+
+If you need something extra on macOS, the official docs recommend installing it with **Homebrew** and **PECL**, then enabling it in Herd's `php.ini`.
+
+That means Herd stays lightweight while still letting you add what a specific project needs.
 
 ## Herd vs Valet vs Sail
 
-- Choose Herd if you want zero dependencies, a simple GUI, and optional Pro services.
-- Choose Valet if you like the Homebrew workflow and a lightweight nginx setup. See the [Valet docs](https://laravel.com/docs/10.x/valet) and my [Valet guide](https://benjamincrozat.com/install-php-mac-laravel-valet).
-- Choose Sail if you want Docker containers that mirror production and need many services.
+Use this shorter rule of thumb:
 
-## Troubleshooting basics
+- choose **Herd** if you want the easiest native local setup on macOS or Windows
+- choose **Valet** if you prefer the Homebrew-style macOS workflow
+- choose **Sail** if you want Docker containers that look more like production
 
-- Restart services from the Herd menu, or run:
+Herd is the easiest recommendation when the main goal is "get Laravel running locally without yak-shaving."
 
-```bash
-herd restart
-```
+## Herd Pro
 
-- On macOS, use the menu option Force stop all if something is stuck, then start again.
+Herd Basic is free.
+
+Herd Pro is the paid tier and the current checkout page describes it as a **one-year license** that works on **macOS and Windows** and can be activated on **up to two devices**.
+
+The Pro tier adds developer-focused tools like:
+
+- service management
+- debugging helpers
+- mail, dump, and log viewers
+
+Because pricing can change, I would always confirm the current details on the official [Herd Pro page](https://herd.laravel.com/checkout).
+
+## Troubleshooting note for Windows
+
+The current Windows docs include one practical fix worth knowing: if Herd feels slow, Windows Defender may be scanning Herd's config folder. The official docs recommend excluding `%USERPROFILE%\\.config\\herd` when Defender is the bottleneck.
+
+That is not always necessary, but it is a useful first thing to check if the Windows install feels unexpectedly sluggish.
 
 ## Platform availability
 
-Herd is available on macOS and Windows. A Linux version is not planned currently. Get the Windows build on the [Herd for Windows page](https://herd.laravel.com/windows/).
+Herd is available on **macOS** and **Windows**.
+
+There is still **no Linux version planned** in the official positioning.
 
 ## Conclusion
 
-If you need to install PHP on macOS or Windows fast, Herd is the easiest way. I suggest starting with the free Basic edition, then adding Pro if you want built‑in services and debugging tools. Next steps: [download Herd](https://herd.laravel.com/download), read the [Windows install docs](https://herd.laravel.com/docs/windows), and check the [PHP versions](https://herd.laravel.com/docs/1/technology/php-versions) and [extensions](https://herd.laravel.com/docs/1/technology/php-extensions) pages.
+If you want the easiest Laravel-friendly local stack on macOS or Windows in 2026, Herd is the simplest recommendation. The main things to remember are that installation now centers around the onboarding flow, the default PHP version is currently **8.5**, and per-project isolation is the feature that really earns its keep.
 
-If you are piecing together your local PHP and Laravel setup, these next reads help with the rest of that environment:
+If you are piecing together the rest of your local setup after Herd, these are the follow-up reads I would keep open:
 
+- [Check whether your PHP version is part of the problem](/check-php-version)
 - [Run PHP and Laravel more smoothly on macOS](/laravel-valet)
 - [Set up Laravel on macOS without a messy local stack](/laravel-installation-macos)
-- [Check whether your PHP version is part of the problem](/check-php-version)
 - [See whether Laravel Forge still fits the way you deploy](/laravel-forge)
 - [Compare hosting options before you deploy another Laravel app](/best-laravel-hosting-providers)

--- a/resources/markdown/posts/laravel-herd.md
+++ b/resources/markdown/posts/laravel-herd.md
@@ -1,14 +1,14 @@
 ---
 id: "01KKEW27CG49GRV02BM10BPV0S"
-title: "How to install Laravel Herd on macOS and Windows"
+title: "Laravel Herd: install it on macOS or Windows"
 slug: "laravel-herd"
 author: "benjamincrozat"
-description: "Install Laravel Herd on macOS or Windows to get PHP, nginx, Composer, Node.js, and .test sites running with less local setup friction."
+description: "Laravel Herd is Laravel's native local PHP development environment for macOS and Windows. Here's how to install it, verify it, and switch PHP versions."
 categories:
   - "laravel"
   - "tools"
-published_at: 2023-07-19T00:00:00+02:00
-modified_at: 2026-03-19T22:39:10Z
+published_at: 2023-07-18T22:00:00Z
+modified_at: 2026-03-19T22:45:00Z
 serp_title: null
 serp_description: null
 canonical_url: null
@@ -19,48 +19,28 @@ sponsored_at: null
 ---
 ## Introduction
 
-**Laravel Herd is the easiest local PHP stack for macOS or Windows if you want PHP, nginx, Composer, Node.js, and `.test` domains without stitching everything together by hand.**
+Laravel Herd is Laravel's native local PHP development environment for macOS and Windows.
 
-If you only need the short version:
+If you want the short version: download Herd from the official site, run the installer, approve the admin prompt when asked, and then verify `herd`, `php`, `composer`, `laravel`, and `node` in your terminal. Herd handles local `.test` domains for you and bundles the PHP, nginx, and Node.js tooling you need to start quickly.
 
-- install **Herd** on **macOS 12+** or **Windows 10+**
-- open it once and finish the onboarding flow
-- verify with `herd --version`, `php --version`, and `composer --version`
-- use `herd isolate` when a project needs a different PHP version
+This guide focuses on the current install flow for both platforms, how Herd handles PHP and Node.js today, and when it makes more sense than [Laravel Valet](/laravel-valet).
 
-The official docs now position Herd as the dependency-light alternative to a Homebrew-heavy or manually assembled local stack.
+## Laravel Herd requirements at a glance
 
-## What Laravel Herd gives you
+- macOS: Herd requires macOS 12 or later.
+- Windows: Herd requires Windows 10 or later and needs administrator privileges during setup.
+- Default project folder: Herd parks `~/Herd` on macOS and `%USERPROFILE%\Herd` on Windows, so projects there are automatically available at `your-project.test`.
 
-After setup, Herd gives you a local environment with:
+## How to install Laravel Herd on macOS
 
-- PHP
-- nginx
-- Composer
-- the Laravel installer
-- Node.js
-- `.test` local domains
-
-That is why Herd is attractive for Laravel work: it gets you from "new machine" to "app running locally" faster than a more manual stack.
-
-## Install Laravel Herd on macOS
-
-### Requirements
-
-According to the official macOS installation docs, Herd requires **macOS 12.0 or later**.
-
-### Installation steps
-
-1. Download the latest macOS build from [the official Herd download page](https://herd.laravel.com/download).
+1. [Download Herd](https://herd.laravel.com/download).
 2. Open the DMG file.
-3. Drag Herd into the **Applications** folder.
-4. Launch Herd to start the onboarding process.
+3. Drag Herd into your Applications folder.
+4. Launch Herd from Applications.
+5. Complete onboarding. Herd downloads the latest stable PHP version, installs its background service, and configures local `.test` routing.
+6. If you already use Valet, Herd can detect your existing Valet sites, certificates, and settings and help you migrate them.
 
-During onboarding, Herd downloads the latest PHP version and installs its background service for nginx and local DNS handling.
-
-If you are moving from Valet, Herd can detect an existing Valet installation and migrate sites, certificates, and settings.
-
-### Verify the install
+### Verify the macOS install
 
 Run:
 
@@ -72,25 +52,23 @@ composer --version
 node --version
 ```
 
-If those commands resolve, the core setup is working.
+If you use Fish shell, add Herd's binaries to your path:
 
-## Install Laravel Herd on Windows
+```bash
+fish_add_path -U $HOME/Library/Application\ Support/Herd/bin/
+```
 
-### Requirements
+## How to install Laravel Herd on Windows
 
-The current Windows installation docs say Herd requires **Windows 10 or higher** and needs **administrator privileges** during setup.
+1. [Download Herd for Windows](https://herd.laravel.com/download/windows).
+2. Run the installer as administrator.
+3. Let the installer add the HerdHelper service, which updates your hosts file and maps your local sites to `.test` domains.
+4. Open Herd and finish setup.
+5. Put Laravel projects in `%USERPROFILE%\Herd` if you want them available automatically as `your-project.test`.
 
-### Installation steps
+### Verify the Windows install
 
-1. Download Herd from [the official Windows download page](https://herd.laravel.com/download/windows).
-2. Run the installer as an administrator.
-3. Open Herd and complete the setup flow.
-
-The Windows installer adds the Herd helper service that handles host-file updates and maps local sites to `.test` domains.
-
-### Verify the install
-
-Run these in PowerShell or Windows Terminal:
+Run these commands in PowerShell or Command Prompt:
 
 ```powershell
 herd --version
@@ -100,103 +78,86 @@ composer --version
 node --version
 ```
 
-## Which PHP version does Herd install?
+### Windows performance note
 
-Herd now ships with the **latest stable PHP version by default**.
+If Herd feels slow on Windows, the official docs recommend excluding `%USERPROFILE%\.config\herd` from Windows Defender scans.
 
-As of **March 19, 2026**, the Herd docs say that default is **PHP 8.5** on both macOS and Windows.
+## What Laravel Herd installs for you
 
-That is a meaningful update from older Herd guides that were anchored to PHP 8.4.
+Herd is designed to be the fast native option for local Laravel work.
 
-## Switching PHP versions globally or per project
+- On macOS, Herd ships with PHP, nginx, dnsmasq, and Node.js tooling.
+- On Windows, Herd ships with PHP, nginx, and Node.js tooling, and uses HerdHelper to handle `.test` mappings.
+- On both platforms, Herd includes the `herd` CLI and lets you use `php`, `composer`, and the Laravel installer from your terminal.
 
-This is one of Herd's best features.
+That makes it a much simpler starting point than piecing together a Homebrew-based stack on macOS or a Docker-based one with Sail.
 
-You can switch the global PHP version:
+## PHP versions in Laravel Herd
+
+Herd now ships with the latest stable PHP version by default. As of March 19, 2026, the official macOS and Windows docs say that default is PHP 8.5.
+
+You can change the global PHP version from the app or with the CLI:
 
 ```bash
-herd use 8.5
+herd use 8.2
 ```
 
-Or isolate a single project to its own PHP version:
+To see what Herd can install and add another version:
 
 ```bash
-cd ~/Sites/my-app
-herd isolate 8.3
+herd php:list
+herd php:install 8.3
+herd php:update 8.4
 ```
 
-Remove that per-project pin with:
+If one project needs a different PHP version than the global default, isolate it:
 
 ```bash
+cd ~/Herd/my-app
+herd isolate 8.1
 herd unisolate
 ```
 
-If you work across older and newer Laravel apps, this is where Herd becomes more useful than a one-version local stack.
+On Windows, the same commands work. If your project lives in the default parked directory, start in `%USERPROFILE%/Herd/my-app` instead.
 
-## Managing extra PHP versions
+If you need help checking which PHP version Laravel is actually using, see [Check PHP version in CLI, browser, or Laravel](/check-php-version).
 
-The current Herd docs focus less on a fixed support matrix and more on managing PHP versions through the app or CLI.
+## Node.js and extensions
 
-The practical takeaway is:
+Herd ships with `nvm` and installs the latest available Node.js version during setup. You can switch Node versions with `nvm use` or isolate a project with Herd's Node commands if you need a different version for one app.
 
-- Herd installs the latest stable PHP version by default
-- you can install additional versions as needed
-- you can set a global version or isolate a single project
+Herd also includes many common PHP extensions out of the box, but the exact list can change by platform and release. If you need something extra:
 
-That is a better mental model than memorizing an older static list of bundled versions.
+- On macOS, Herd's docs recommend installing extra extensions with Homebrew and PECL, then enabling them in `~/Library/Application Support/Herd/config/php/<version>/php.ini`.
+- On Windows, Herd's docs point you to non-thread-safe Windows builds from PECL and to `%USERPROFILE%\.config\herd\bin\<version>\php.ini` for activation.
 
-## PHP extensions in Herd
+For the always-current details, check the official [macOS PHP extensions docs](https://herd.laravel.com/docs/macos/technology/php-extensions) or [Windows PHP extensions docs](https://herd.laravel.com/docs/windows/technology/php-extensions).
 
-Herd includes many extensions out of the box, but not every possible one.
-
-If you need something extra on macOS, the official docs recommend installing it with **Homebrew** and **PECL**, then enabling it in Herd's `php.ini`.
-
-That means Herd stays lightweight while still letting you add what a specific project needs.
-
-## Herd vs Valet vs Sail
-
-Use this shorter rule of thumb:
-
-- choose **Herd** if you want the easiest native local setup on macOS or Windows
-- choose **Valet** if you prefer the Homebrew-style macOS workflow
-- choose **Sail** if you want Docker containers that look more like production
-
-Herd is the easiest recommendation when the main goal is "get Laravel running locally without yak-shaving."
-
-## Herd Pro
+## Laravel Herd Pro pricing
 
 Herd Basic is free.
 
-Herd Pro is the paid tier and the current checkout page describes it as a **one-year license** that works on **macOS and Windows** and can be activated on **up to two devices**.
+Herd Pro starts at $99 per year for one license, and that license can be activated on two devices at the same time. Team licenses start at $299. Pro adds the integrated services and debugging tools that Herd does not include in the free tier by default.
 
-The Pro tier adds developer-focused tools like:
+If you do not renew, Herd drops back to the free version. The official pricing page also says there is a 14-day refund policy.
 
-- service management
-- debugging helpers
-- mail, dump, and log viewers
+## Herd vs Valet vs Sail
 
-Because pricing can change, I would always confirm the current details on the official [Herd Pro page](https://herd.laravel.com/checkout).
+- Choose Herd if you want the fastest native Laravel setup on macOS or Windows, with `.test` domains, GUI controls, and optional Pro services.
+- Choose [Laravel Valet](/laravel-valet) if you are on macOS and prefer a lighter, CLI-first workflow built around Homebrew.
+- Choose Sail if you want Docker containers because you need closer parity with a containerized production setup.
 
-## Troubleshooting note for Windows
+## Is Laravel Herd available on Linux?
 
-The current Windows docs include one practical fix worth knowing: if Herd feels slow, Windows Defender may be scanning Herd's config folder. The official docs recommend excluding `%USERPROFILE%\\.config\\herd` when Defender is the bottleneck.
-
-That is not always necessary, but it is a useful first thing to check if the Windows install feels unexpectedly sluggish.
-
-## Platform availability
-
-Herd is available on **macOS** and **Windows**.
-
-There is still **no Linux version planned** in the official positioning.
+No. The official Herd pricing FAQ says there are currently no plans for a Linux version.
 
 ## Conclusion
 
-If you want the easiest Laravel-friendly local stack on macOS or Windows in 2026, Herd is the simplest recommendation. The main things to remember are that installation now centers around the onboarding flow, the default PHP version is currently **8.5**, and per-project isolation is the feature that really earns its keep.
+Laravel Herd is the easiest way to get a modern Laravel PHP environment running on macOS or Windows without piecing the stack together yourself. For most Laravel projects, the free tier is enough to get started, and the install flow is now straightforward on both platforms.
 
-If you are piecing together the rest of your local setup after Herd, these are the follow-up reads I would keep open:
+If you are building out the rest of your local Laravel setup, these next reads are the most relevant:
 
-- [Check whether your PHP version is part of the problem](/check-php-version)
-- [Run PHP and Laravel more smoothly on macOS](/laravel-valet)
-- [Set up Laravel on macOS without a messy local stack](/laravel-installation-macos)
-- [See whether Laravel Forge still fits the way you deploy](/laravel-forge)
-- [Compare hosting options before you deploy another Laravel app](/best-laravel-hosting-providers)
+- [How to install Laravel Valet on macOS](/laravel-valet)
+- [How to install Laravel on macOS](/laravel-installation-macos)
+- [Check PHP version in CLI, browser, or Laravel](/check-php-version)
+- [Latest Laravel version and support status](/laravel-versions)

--- a/resources/markdown/posts/laravel-versions.md
+++ b/resources/markdown/posts/laravel-versions.md
@@ -3,11 +3,11 @@ id: "01KKEW27EBJJREQW7SC8BS8P5Y"
 title: "Laravel versions: latest release and support status"
 slug: "laravel-versions"
 author: "benjamincrozat"
-description: "See the latest Laravel version, which releases are still supported, whether any LTS branch exists, and how Laravel's support policy works."
+description: "See the latest Laravel version, which majors are still supported, and how long bug-fix and security support lasts."
 categories:
   - "laravel"
 published_at: 2023-09-20T00:00:00+02:00
-modified_at: 2026-03-14T10:17:05Z
+modified_at: 2026-03-19T22:39:10Z
 serp_title: null
 serp_description: null
 canonical_url: ""
@@ -18,82 +18,104 @@ sponsored_at: null
 ---
 ## Introduction
 
-**If you want the short answer first: Laravel 12 is the latest fully documented major release on Laravel's official [release-notes page](https://laravel.com/docs/releases) as of March 14, 2026.**
+**Laravel 13 is the latest Laravel major release as of March 19, 2026.**
 
-That same support-policy table already lists Laravel 13 for `Q1 2026`, so this is one of those moments where the support matrix is slightly ahead of the narrative release notes.
+If you only need the fast answer:
 
-## The latest stable version of Laravel
+- **Laravel 13** is the current major release.
+- **Laravel 12** is still fully supported.
+- **Laravel 11** reached the end of security support on **March 12, 2026**.
+- There is **no current LTS release**.
 
-According to Laravel's official [release notes](https://laravel.com/docs/releases) and [GitHub releases](https://github.com/laravel/framework/releases):
+This page used to be a freshness pass for Laravel 12, but the official framework release changed quickly: `v13.0.0` was published on **March 17, 2026**, and `v13.1.1` followed on **March 18, 2026**.
 
-- **Laravel 12** is the latest documented major release.
-- **Laravel 12** was released on **February 24, 2025**.
-- **Laravel 12** receives bug fixes until **August 13, 2026** and security fixes until **February 24, 2027**.
+## The latest Laravel version
 
-If you just need to know what to target in production today, Laravel 12 is the safe default answer.
+According to Laravel's official release notes and framework releases:
 
-## The latest LTS (Long Term Support) release of Laravel
+- **Laravel 13** is the latest documented major release.
+- **Laravel 13.0.0** was published on **March 17, 2026**.
+- The latest framework release visible on GitHub as of **March 19, 2026** is **Laravel 13.1.1**, published on **March 18, 2026**.
 
-There is **no current LTS release** of Laravel.
+If you are choosing a version for a new app today, **Laravel 13** is the default target.
+
+## Supported Laravel versions right now
+
+Here is the current support picture from Laravel's official support-policy table, interpreted on **March 19, 2026**:
+
+| Version | PHP | Release | Bug fixes until | Security fixes until | Status on March 19, 2026 |
+| --- | --- | --- | --- | --- | --- |
+| Laravel 11 | 8.2 - 8.4 | March 12, 2024 | September 3, 2025 | March 12, 2026 | End of support |
+| Laravel 12 | 8.2 - 8.5 | February 24, 2025 | August 13, 2026 | February 24, 2027 | Supported |
+| Laravel 13 | 8.3 - 8.5 | Q1 2026 in the docs table | Q3 2027 | Q1 2028 | Current major release |
+
+One subtle detail: the docs support table still labels Laravel 13's release date broadly as **Q1 2026**, even though the framework release itself was published on **March 17, 2026**.
+
+## What this means in practice
+
+### If you are on Laravel 13
+
+You are on the latest major and the right default track for new work.
+
+### If you are on Laravel 12
+
+You are still in a healthy place. There is no emergency, but you should treat Laravel 13 as your next routine upgrade target.
+
+### If you are on Laravel 11
+
+You are now past the last day of official security support. That deadline was **March 12, 2026**.
+
+If that is your current branch, I would stop thinking in terms of "later this year" and start planning the upgrade now.
+
+## Is there a current Laravel LTS release?
+
+No. Laravel no longer ships special LTS majors.
 
 The last LTS release was **Laravel 6**, released on **September 3, 2019**.
 
-Earlier LTS releases were:
-
-- Laravel 5.1
-- Laravel 5.5
-- Laravel 6
-
-Modern Laravel does not use special LTS majors anymore. The framework now follows a support policy with **18 months of bug fixes** and **2 years of security fixes** for each major release.
-
-## The currently supported Laravel versions
-
-Here is the status from Laravel's official support table as of **March 14, 2026**:
-
-| Version | Release | Bug fixes until | Security fixes until | Status on March 14, 2026 |
-| --- | --- | --- | --- | --- |
-| Laravel 11 | March 12, 2024 | September 3, 2025 | March 12, 2026 | Security support just ended |
-| Laravel 12 | February 24, 2025 | August 13, 2026 | February 24, 2027 | Supported |
-| Laravel 13 | Q1 2026 | Q3 2027 | Q1 2028 | Listed in the support policy table |
-
-So, if you are still on Laravel 11, **March 12, 2026** was your last day of official security support.
-
-## See which version of Laravel you are running
-
-Knowing which version of Laravel you are running matters when you are planning an upgrade, checking package compatibility, or reading framework docs.
-
-Check out: [Ways to check which Laravel version you are running](https://benjamincrozat.com/check-laravel-version)
-
-## How Laravel's support policy works
-
-Laravel's current policy is simple:
+The modern policy is simpler:
 
 - bug fixes for **18 months**
 - security fixes for **2 years**
-- weekly minor and patch releases
-- major releases around **Q1**
+- major releases roughly once per year
 
-That means Laravel upgrades are meant to be routine maintenance, not something you postpone for years.
+That is why keeping up with Laravel now is mostly a maintenance habit, not a once-every-few-years migration event.
 
-## Quick Laravel version timeline
+## Which PHP version does each current Laravel major need?
 
-If you only want the broad picture, this is the useful timeline:
+This is the short version from the release notes:
 
-- **Laravel 5.1** introduced the first LTS release.
-- **Laravel 5.5** was another LTS release.
-- **Laravel 6** was the last LTS release.
-- **Laravel 8 and later** shifted into the modern annual major-release cadence and current support policy.
-- **Laravel 12** is the latest fully documented release on the official release-notes page.
+- **Laravel 11**: PHP **8.2 - 8.4**
+- **Laravel 12**: PHP **8.2 - 8.5**
+- **Laravel 13**: PHP **8.3 - 8.5**
 
-If you need the deeper archive for older majors, Laravel keeps release notes for old versions in its documentation archive.
+So if you are preparing for Laravel 13, make sure your environment is already on **PHP 8.3 or newer**.
+
+If you need to confirm the runtime first, check out [how to check your PHP version](/check-php-version).
+
+## How to check which Laravel version your app is running
+
+If you are not sure which version is actually installed, the quickest next step is here:
+
+[Ways to check which Laravel version you are running](/check-laravel-version)
+
+That is the practical companion to this page. This article tells you what is current; that one tells you what your project is actually using.
+
+## Should you upgrade now?
+
+My short rule of thumb:
+
+- Upgrade to **Laravel 13** for new applications.
+- Keep **Laravel 12** on your near-term upgrade roadmap, not your panic list.
+- Move off **Laravel 11** as soon as reasonably possible because security support ended on **March 12, 2026**.
 
 ## Conclusion
 
-Laravel 12 is the current documented answer, Laravel 11 fell out of security support on **March 12, 2026**, and there is no active LTS branch to hide on. If you are planning upgrades, target Laravel 12 now and keep an eye on Laravel 13's official release notes once that page lands.
+Laravel 13 is the latest Laravel release on **March 19, 2026**, Laravel 12 is still comfortably supported, and Laravel 11 is now out of support. There is no active LTS branch to wait for, so the safest long-term habit is to keep upgrades routine.
 
-If you are using the version map to plan what comes next, these are the follow-up reads I would keep open:
+If you are planning the next move after checking the version map, these are the follow-up reads I would keep open:
 
 - [Double-check which Laravel version is actually running](/check-laravel-version)
-- [See what Laravel 13 is shaping up to change](/laravel-13)
-- [See what Laravel 12 changed before you adopt it](/laravel-12)
-- [Plan a safer upgrade from Laravel 11](/laravel-11-upgrade-guide)
+- [See what changed in Laravel 13](/laravel-13)
+- [Review Laravel 12 before an intermediate upgrade](/laravel-12)
+- [Plan a safer upgrade path off Laravel 11](/laravel-11-upgrade-guide)

--- a/resources/markdown/posts/php-enums.md
+++ b/resources/markdown/posts/php-enums.md
@@ -1,13 +1,13 @@
 ---
 id: "01KKEW27KKSV7D18ZBY0ZH2WJ0"
-title: "PHP enums explained with examples"
+title: "PHP enums: backed vs unit enums with examples"
 slug: "php-enums"
 author: "benjamincrozat"
-description: "Learn what PHP enums are, how to declare them, and when to use backed enums and enum methods."
+description: "Learn when to use PHP enums, how unit and backed enums differ, and how to model real application states safely."
 categories:
   - "php"
 published_at: 2023-07-05T00:00:00+02:00
-modified_at: 2026-03-13T12:20:00Z
+modified_at: 2026-03-19T22:39:10Z
 serp_title: null
 serp_description: null
 canonical_url: ""
@@ -18,415 +18,286 @@ sponsored_at: null
 ---
 ## Introduction
 
-**PHP enums let you model a fixed set of possible values as a real type.**
+**PHP enums let you model a fixed list of allowed values as a real type.**
 
-They are useful when a value should only ever be one of a small number of allowed options, such as a user status, an order state, or an app environment.
+If you only need the quick answer:
 
-PHP added enums in PHP 8.1, and they make this kind of code clearer, safer, and easier to maintain. Here is how they work, with practical examples.
+- Use a **unit enum** when the case itself is enough.
+- Use a **backed enum** when you also need a stable string or integer value for a database, API, queue payload, or config file.
 
-## A brief history of Enums in PHP
+Native enums were added in **PHP 8.1**, and the PHP manual describes them as a special kind of object. That makes them much safer than passing raw strings like `"draft"` or `"published"` around your app.
 
-### Before PHP 8.1
+## When PHP enums are worth using
 
-PHP did not have built-in support for Enums. While this lack of Enums did not prevent developers from writing code, it did mean that PHP lacked a tool found in many other languages that can make coding safer and more efficient.
+Enums are a good fit when a value should only ever be one of a small number of valid choices.
 
-Without built-in Enums, developers had to use other constructs to represent a set of possible values, often resorting to class constants, arrays, or sometimes just strings or integers.
+Typical examples:
 
-However, this could lead to potential errors and often resulted in code that was not as clear as it could be.
+- order status
+- user role
+- payment state
+- app environment
+- HTTP method
 
-### PHP 8.1
-
-The introduction of Enums in PHP 8.1 has been a significant addition to the language.
-
-PHP's implementation of Enums is more powerful than many other languages, as Enums in PHP are not merely integer or string values under the hood.
-
-In PHP, an Enum is a special kind of object, with cases of the Enum being single-instance objects of that class.
-
-This means you can use Enums anywhere you could use an object, making them extremely versatile.
-
-The addition of Enums to PHP signifies the language's ongoing evolution to incorporate more modern programming concepts and paradigms, increasing its efficiency, and enabling developers to write safer and cleaner code.
-
-## Understanding the basics of Enums in PHP
-
-To unravel the basics of Enums in PHP, I decided to use the magical world of Harry Potter.
-
-Imagine we're coding for the Hogwarts School of Witchcraft and Wizardry, where each new student must be sorted into a house by the virtual Sorting Hat.
-
-At Hogwarts, there are only four houses: Gryffindor, Hufflepuff, Ravenclaw, and Slytherin.
-
-So, we could represent this as an Enum in PHP.
-
-Here's how you declare an Enum:
+Without enums, those values often end up as loose strings, which makes typos and invalid states easier to miss.
 
 ```php
-<?php
+$status = 'publshed'; // typo, but still a string
+```
 
-enum House
+With an enum, PHP restricts the value to known cases:
+
+```php
+enum PostStatus
 {
-    case Gryffindor;
-    case Hufflepuff;
-    case Ravenclaw;
-    case Slytherin;
+    case Draft;
+    case Published;
+    case Archived;
 }
 ```
 
-In this example, we have created an Enum named House, which can have four possible values - `Gryffindor`, `Hufflepuff`, `Ravenclaw`, and `Slytherin`.
+Now a property, argument, or return type can only be one of those three cases.
 
-Let's create a `Student` class, where each student holds a `$house` property.
+## Unit enums vs backed enums
+
+This is the part most people are actually trying to sort out.
+
+| Type | Best for | Stores scalar value? | Common example |
+| --- | --- | --- | --- |
+| Unit enum | In-memory app logic | No | workflow states |
+| Backed enum | Database or API values | Yes | `draft`, `published`, `archived` |
+
+### Use a unit enum when the case name is enough
+
+Unit enums only define cases:
 
 ```php
-class Student
+enum ServerEnvironment
 {
-    public ?House $house = null;
+    case Local;
+    case Staging;
+    case Production;
 }
 ```
 
-We also have a `SortingHat` class with a `sort` method.
+This is great when you just need a constrained value inside your application.
 
-This method either accepts a house suggestion or randomly assigns a house to the student.
+### Use a backed enum when you need a stable stored value
 
-Just like in Harry Potter, the Sorting Hat took Harry's choice into consideration!
-
-```php
-class SortingHat
-{   
-    public function sort(Student $student, ?House $suggestedHouse = null)
-    {
-        if ($suggestedHouse) {
-            $student->house = $suggestedHouse;
-            
-            return;
-        }
-
-        $houses = [
-            House::Gryffindor,
-            House::Hufflepuff,
-            House::Ravenclaw,
-            House::Slytherin,
-        ];
-
-        $index = array_rand($houses);
-        
-        $student->house = $houses[$index];
-    }
-}
-```
-
-As you can see, we've limited the values of the `$suggestedHouse` variable and `$house` property to only be one of the four Hogwarts houses using the `House` Enum.
-
-If you were to try to sort a student into a non-existent house, PHP will catch this, and it wouldn't run.
-
-That's the magic of Enums!
-
-In this scenario, the Hogwarts houses with no associated data are called "Pure Cases," and an Enum that contains only Pure Cases, like our House Enum, is referred to as a "Pure Enum."
-
-## Pure Enums VS. backed Enums
-
-Backed Enums are Enums backed with a scalar value. That's why they are considered "not pure."
-
-For a reminder, a scalar value in PHP is either of type `bool`, `float`, `int` or `string`.
-
-Code speaks more than words sometimes, so here's a Backed Enum:
+Backed enums attach each case to a `string` or `int`:
 
 ```php
-<?php
-
-enum House: string
+enum PostStatus: string
 {
-    case Gryffindor = 'Gryffindor';
-    case Hufflepuff = 'Hufflepuff';
-    case Ravenclaw = 'Ravenclaw';
-    case Slytherin = 'Slytherin';
+    case Draft = 'draft';
+    case Published = 'published';
+    case Archived = 'archived';
 }
 ```
 
-As you can see, we defined the type that backs the Enum (`string` in that case) and we assign a value to each case. Couldn't be simpler than that. But why would you use Backed Enums?
+That is usually the better choice when you need to:
 
-Here's a great use case:
+- save the value in a database
+- send it in JSON
+- receive it from an API
+- keep values stable even if you rename a case later
+
+## A practical backed-enum example
+
+Here is the common Laravel or plain PHP scenario: you read a string from storage and want a typed enum again.
 
 ```php
-// Let's pretend we fetched this value from the database.
-$house = 'Gryffindor';
+enum OrderStatus: string
+{
+    case Pending = 'pending';
+    case Paid = 'paid';
+    case Refunded = 'refunded';
+}
 
-$student = new Student(
-    House::from($house)
-);
+$status = OrderStatus::from('paid');
 
-// object(Student)#1 (1) {
-//   ["house"]=>
-//   enum(House::Gryffindor)
-// }
-var_dump($student);
+var_dump($status === OrderStatus::Paid); // true
 ```
 
-In this example:
-1. We pretend we fetched data from a database and we try to create a new `Student` object.
-2. We initialize the `$house` property with the `House::from()` static method from a string value (since `House` is now a backed enum of type `string`).
-3. If this fails, an exception is throw. (`Uncaught ValueError: "Foo" is not a valid backing value for enum "House"`)
-
-In some cases, instead of throwing an exception, you might want to fall back on a default value. Here's how you can do that with the `House::tryFrom()` static method, which returns `null` in case of failure.
+If the value may be invalid, use `tryFrom()` instead of `from()`:
 
 ```php
-$student = new Student(
-    House::tryFrom('Slytherin') ?? House::Gryffindor
+$status = OrderStatus::tryFrom($request['status']) ?? OrderStatus::Pending;
+```
+
+- `from()` throws a `ValueError` for an invalid value
+- `tryFrom()` returns `null`
+
+That small difference matters a lot when the data comes from a request, CSV import, or third-party API.
+
+## Listing enum cases
+
+All enums can list their cases with `cases()`:
+
+```php
+enum UserRole
+{
+    case Admin;
+    case Editor;
+    case Viewer;
+}
+
+$roles = UserRole::cases();
+```
+
+That is useful for:
+
+- select options
+- validation rules
+- docs or debug output
+- random test data
+
+If you are using a backed enum and want just the scalar values, map over the cases:
+
+```php
+$values = array_map(
+    fn (OrderStatus $status) => $status->value,
+    OrderStatus::cases(),
 );
 ```
 
-## Listing Enum values
+## Enum methods are where they start paying off
 
-You saw in the previous example that without a suggestion from the student, a house is randomly assigned.
-
-What bothers me in the example I provided, though, is that we manually listed the possible values of the `House` Enum to build our array.
-
-Fortunately, Enums all have a `cases()` method that can make our code more flexible!
+Enums are not just constants with nicer syntax. You can add methods and keep related logic close to the cases.
 
 ```php
-class SortingHat
-{   
-    public function sort(Student $student, ?House $suggestedHouse = null)
-    {
-        if ($suggestedHouse) {
-            $student->house = $suggestedHouse;
-            
-            return;
-        }
-
-        $houses = [
-            House::Gryffindor,
-            House::Hufflepuff,
-            House::Ravenclaw,
-            House::Slytherin,
-        ];
-	    $houses = House::cases();
-
-        $index = array_rand($houses);
-        
-        $student->house = $houses[$index];
-    }
-}
-```
-
-Pretty neat, right?
-
-## A deep dive into PHP Enums and their comparison with classes
-
-In our journey with PHP Enums so far, you might have noticed that they are similar to classes.
-
-They can be namespaced, implement interfaces, use traits, and they are also autoloadable in the same way.
-
-But, of course, there are also some significant differences between PHP classes and Enums.
-
-Let's revisit our magical Harry Potter example to understand these differences.
-
-When a student is sorted into a house by the Sorting Hat, we know that the house will always be one of the four predefined options - `Gryffindor`, `Hufflepuff`, `Ravenclaw`, or `Slytherin`. 
-
-There are no other possibilities in the context of Hogwarts. This scenario is perfect for Enums.
-
-An Enum, like `House`, is a unique data type that comprises a set of predefined constants.
-
-It signifies that a variable can have only one of these predefined constants and nothing else.
-
-For example, the `$house` property of the `Student` class can only hold one of the four house options defined in the `House` Enum.
-
-```php
-class Student
+enum OrderStatus: string
 {
-    public ?House $house = null;
-}
-```
+    case Pending = 'pending';
+    case Paid = 'paid';
+    case Refunded = 'refunded';
 
-In contrast, classes in PHP, like our `Student` class, can hold a variety of different properties and can be instantiated multiple times with different property values.
-
-Enums, on the other hand, cannot be instantiated and are used to define a fixed, limited set of instances.
-
-Another difference is in the way we compare classes and Enums. 
-
-In PHP, Enums are compared by their identity, not by their values.
-
-Let's take a look at an example:
-
-```php
-$a = House::Gryffindor;
-$b = House::Gryffindor;
-
-var_dump($a === $b); // bool(true)
-```
-
-In this example, `$a` and `$b` are the same `House` Enum instance, so `$a === $b` is `true`.
-
-Comparisons using less than `<` or greater than `>` operators are not meaningful for Enum objects and will always return false.
-
-Enum cases in PHP have a special property called `name`, which is the case-sensitive name of the case itself. This can be useful when you want to print the name of the Enum case.
-
-```php
-echo House::Gryffindor->name; // Prints "Gryffindor".
-```
-
-## Working with enum methods
-
-Now that we've explored how Enums can be compared and their differences from classes, it's time to dive deeper and explore enumeration methods in PHP Enums.
-
-Just like classes, Enums in PHP can contain methods.
-
-Let's see how we can utilize this feature using our Harry Potter sorting scenario.
-
-```php
-enum House
-{
-    case Gryffindor;
-    case Hufflepuff;
-    case Ravenclaw;
-    case Slytherin;
-
-    public function getHouseColors() : array
+    public function label(): string
     {
-        return match($this) {
-            House::Gryffindor => ['Red', 'Gold'],
-            House::Hufflepuff => ['Yellow', 'Black'],
-            House::Ravenclaw => ['Blue', 'Bronze'],
-            House::Slytherin => ['Green', 'Silver'],
+        return match ($this) {
+            self::Pending => 'Pending payment',
+            self::Paid => 'Paid',
+            self::Refunded => 'Refunded',
         };
     }
-}
 
-// array(2) {
-//   [0]=>
-//   string(3) "Red"
-//   [1]=>
-//   string(4) "Gold"
-// }
-var_dump(House::Gryffindor->getHouseColors());
-```
-
-In the magical world of Hogwarts, every house has its colors. In our example above, we've added a `getHouseColor()` method to our `House` Enum to return the color of each house.
-
-When a method is defined within an Enum, the `$this` variable is defined and refers to the case instance.
-
-## Enums can use Traits and implement Interfaces
-
-Like classes, Enums can use Traits. This is great when there are a lot of methods and you need to split them across multiple files to keep your code tidier.
-
-There are some restrictions, though:
-- You can't have properties.
-- You can't override Enums methods (like `cases()`).
-
-```php
-trait Colors
-{
-    public function getHouseColors() : array
+    public function isFinal(): bool
     {
-        return match($this) {
-            House::Gryffindor => ['Red', 'Gold'],
-            House::Hufflepuff => ['Yellow', 'Black'],
-            House::Ravenclaw => ['Blue', 'Bronze'],
-            House::Slytherin => ['Green', 'Silver'],
-        };
-    }
-}
-
-enum House
-{
-    use Colors;
-  
-    case Gryffindor;
-    case Hufflepuff;
-    case Ravenclaw;
-    case Slytherin;
-}
-```
-
-Like like Traits in Classes, Interfaces can also be implemented into Enums. It's difficult to find a concrete example for this use case, but here you go anyway:
-
-```php
-interface HasColors
-{
-    public function getHouseColors() : array;
-}
-
-enum House implements HasColors
-{
-    case Gryffindor;
-    case Hufflepuff;
-    case Ravenclaw;
-    case Slytherin;
-  
-    public function getHouseColors() : array
-    {
-        return match($this) {
-            House::Gryffindor => ['Red', 'Gold'],
-            House::Hufflepuff => ['Yellow', 'Black'],
-            House::Ravenclaw => ['Blue', 'Bronze'],
-            House::Slytherin => ['Green', 'Silver'],
+        return match ($this) {
+            self::Pending => false,
+            self::Paid, self::Refunded => true,
         };
     }
 }
 ```
 
-## What about Enums in PHP 7 or even PHP 5?
+That keeps your code easier to read than scattering `match` blocks throughout controllers, jobs, and views.
 
-Before the introduction of native Enumerations in PHP 8.1, enums were typically handled in PHP in a few different ways, none of which were particularly elegant or reliable. Here are some of the common strategies:
+## Real use cases for PHP enums
 
-- **Class constants:** Perhaps the most common way of implementing enums was through class constants. Here's an example:
+Here are the patterns I see most often in real projects.
+
+### Database-backed state
+
+Use a backed enum for values that live in a table:
 
 ```php
-class House
+enum SubscriptionStatus: string
 {
-    const Gryffindor = 'Gryffindor';
-    const Hufflepuff = 'Hufflepuff';
-    const Ravenclaw = 'Ravenclaw';
-    const Slytherin = 'Slytherin';
+    case Trialing = 'trialing';
+    case Active = 'active';
+    case Canceled = 'canceled';
 }
 ```
 
-In this way, you could refer to an enum value with House::Gryffindor, for instance. This approach provides a way to group related constants, but doesn't provide any of the type safety or functionality that true enums might offer (because class constants cannot be typed and marked as readonly).
+### API-friendly values
 
-- **Arrays:** Another common way was to use arrays to hold possible values.
-
-```php
-$houses = [
-    'Gryffindor', 
-    'Hufflepuff',
-    'Ravenclaw',
-    'Slytherin',
-];
-```
-
-However, this method also lacks the benefits of true Enums such as type safety and autocompletion.
-
-- **[SplEnum](http://php.adamharvey.name/manual/en/class.splenum.php):** PHP used to have a built-in SplEnum class, which was a part of the Standard PHP Library (SPL). However, it was not widely adopted due to its performance issues and it required the SPL Types extension which was not bundled with PHP and was considered experimental.
+If an external API expects `"GET"` or `"POST"`, a backed enum gives you safer code:
 
 ```php
-class House extends SplEnum
+enum HttpMethod: string
 {
-    const Gryffindor = 'Gryffindor';
-    const Hufflepuff = 'Hufflepuff';
-    const Ravenclaw = 'Ravenclaw';
-    const Slytherin = 'Slytherin';
+    case Get = 'GET';
+    case Post = 'POST';
+    case Put = 'PUT';
+    case Delete = 'DELETE';
 }
 ```
 
-This class was removed in PHP 7.0, so it's not used anymore.
+### Domain rules with methods
 
-- **Third-party packages:** There are also several packages that provide enum functionality, such as [myclabs/php-enum](https://packagist.org/packages/myclabs/php-enum). These often provide more features than simple class constants or arrays, such as methods for listing all possible values, converting to/from strings, etc.
+Enums become especially useful when the value has behavior:
 
 ```php
-use MyCLabs\Enum\Enum;
-
-class House extends Enum
+enum InvoiceStatus: string
 {
-    const Gryffindor = 'Gryffindor';
-    const Hufflepuff = 'Hufflepuff';
-    const Ravenclaw = 'Ravenclaw';
-    const Slytherin = 'Slytherin';
+    case Draft = 'draft';
+    case Sent = 'sent';
+    case Paid = 'paid';
+
+    public function canBeEdited(): bool
+    {
+        return $this !== self::Paid;
+    }
 }
 ```
 
-Despite these workarounds, none of them could provide the full set of features that true Enumerations can offer, such as type safety and functionality like getting all possible values.
+## Traits and interfaces also work
 
-This is why the addition of native Enumerations in PHP 8.1 was such an important upgrade for the language.
+Enums can implement interfaces and use traits, which is handy when several enums should share a contract.
 
-If you are exploring the newer PHP building blocks that make domain code cleaner, these are the next reads I would open:
+```php
+interface HasLabel
+{
+    public function label(): string;
+}
 
+enum Visibility: string implements HasLabel
+{
+    case Public = 'public';
+    case Private = 'private';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Public => 'Public',
+            self::Private => 'Private',
+        };
+    }
+}
+```
+
+That said, enums are still more restricted than normal classes. They are not general-purpose objects.
+
+## Common enum gotchas
+
+These are the mistakes that usually trip people up:
+
+- Enums require **PHP 8.1 or newer**.
+- A backed enum can only use `string` or `int`.
+- Use `from()` only when you trust the input.
+- Store **backed enum values** in databases, not case names, unless you have a very specific reason not to.
+- A unit enum has `name`, but not `value`.
+
+Another practical rule: if the value must cross a storage or network boundary, a backed enum is usually the safer default.
+
+## What if you are stuck on PHP 7 or older?
+
+If you cannot use PHP 8.1 yet, your fallback is usually class constants or a small value object. That works, but you lose the native enum ergonomics and type safety.
+
+```php
+final class LegacyPostStatus
+{
+    public const DRAFT = 'draft';
+    public const PUBLISHED = 'published';
+    public const ARCHIVED = 'archived';
+}
+```
+
+That is serviceable, but native enums are cleaner, harder to misuse, and easier to extend with methods.
+
+If you are deciding whether to use enums or older PHP patterns, these are the next reads I would open:
+
+- [Use `match` when `switch` starts feeling clumsy](/a-quick-look-at-the-php-match-expression)
 - [Make PHP serialization finally click without the usual confusion](/a-friendly-guide-to-php-serialization-that-finally-clicked)
-- [Use match when switch starts feeling clumsy](/a-quick-look-at-the-php-match-expression)
 - [See where the state machine pattern helps in PHP](/a-friendly-intro-to-the-state-machine-pattern-in-php)

--- a/seo-editorial-plan.md
+++ b/seo-editorial-plan.md
@@ -1,6 +1,6 @@
 # SEO editorial plan
 
-Last updated: March 18, 2026
+Last updated: March 19, 2026
 Source brief: fresh Search Console export from the browser plus live Google US desktop SERP checks on March 18, 2026
 
 This is the working SEO backlog for the next article batch and refresh cycle. We should move through it from top to bottom unless fresh Search Console or SERP data changes the priority. Check an item only when the article is drafted or refreshed, reviewed, synced, and ready to publish.
@@ -54,27 +54,27 @@ This is the working SEO backlog for the next article batch and refresh cycle. We
   - Why update now: Same practical-example opportunity as `array_map`.
   - Core update: Strengthen the intro, empty-value caveats, and filtering-by-key examples.
 
-- [ ] `/php-enums`
+- [x] `/php-enums`
   - Keyword cluster: `php enum`
   - Why update now: Strong evergreen fit and good impression volume.
   - Core update: Add better backed-vs-unit enum guidance and more real use cases.
 
-- [ ] `/laravel-versions`
+- [x] `/laravel-versions`
   - Keyword cluster: `latest laravel version`, `laravel 11 release date`
   - Why update now: The page already matches the intent cluster, but it needs a freshness pass.
   - Core update: Lead with Laravel 12 as current and label Laravel 13 as upcoming on March 18, 2026.
 
-- [ ] `/check-php-version`
+- [x] `/check-php-version`
   - Keyword cluster: `check php version`
   - Why update now: Useful utility query with a page that can answer faster.
   - Core update: Improve the quick answer and split the methods cleanly by CLI, browser, and Laravel.
 
-- [ ] `/bun-package-manager`
+- [x] `/bun-package-manager`
   - Keyword cluster: `bun vs pnpm`, `bun vs npm`
   - Why update now: `bun vs pnpm` already shows the best traction in this cluster.
   - Core update: Add a clearer comparison table and a stronger recommendation framework for when Bun is worth switching to.
 
-- [ ] `/laravel-herd`
+- [x] `/laravel-herd`
   - Keyword cluster: `laravel herd`
   - Why update now: Good intent fit, but the query is still partly navigational.
   - Core update: Refresh screenshots and installation notes for current macOS and Windows behavior.


### PR DESCRIPTION
## Summary
- refresh `php-enums` around clearer backed vs unit guidance and real-world examples
- update `laravel-versions` for the Laravel 13 release and current support picture
- tighten `check-php-version` around CLI, browser, and Laravel-specific methods
- reframe `bun-package-manager` around Bun vs pnpm vs npm switching decisions
- refresh `laravel-herd` installation and PHP version guidance for current docs

## Verification
- `php artisan app:sync-posts`
